### PR TITLE
Remove "M" in Header for Logo Image

### DIFF
--- a/js/packages/web/src/components/Notifications/index.tsx
+++ b/js/packages/web/src/components/Notifications/index.tsx
@@ -457,7 +457,7 @@ export function Notifications() {
       content={content}
       trigger="click"
     >
-      <h1 className="title">M</h1>
+      <h1 className="title" />
     </Popover>
   );
 


### PR DESCRIPTION
### Changes

The holaplex stylesheet provides an logo image as a backround image on the `.title` classname