### PR TITLE
Use Arweave CDN for NFT Assets

### DIFF
--- a/js/packages/web/next.config.js
+++ b/js/packages/web/next.config.js
@@ -28,6 +28,7 @@ module.exports = withPlugins(plugins, {
     ignoreDuringBuilds: true,
   },
   env: {
+    NEXT_PUBLIC_ARWEAVE_CDN: process.env.ARWEAVE_CDN,
     NEXT_PUBLIC_STORE_OWNER_ADDRESS:
       process.env.STORE_OWNER_ADDRESS ||
       process.env.REACT_APP_STORE_OWNER_ADDRESS_ADDRESS,

--- a/js/packages/web/src/hooks/useArt.ts
+++ b/js/packages/web/src/hooks/useArt.ts
@@ -15,6 +15,16 @@ import { Cache } from 'three';
 import { useInView } from 'react-intersection-observer';
 import { pubkeyToString } from '../utils/pubkeyToString';
 
+const ARWEAVE_CDN = process.env.NEXT_PUBLIC_ARWEAVE_CDN;
+
+const routeCDN = (uri: string) => {
+  if (ARWEAVE_CDN) {
+    return uri.replace('https://arweave.net', ARWEAVE_CDN);
+  }
+
+  return uri;
+};
+
 const metadataToArt = (
   info: Metadata | undefined,
   editions: Record<string, ParsedAccount<Edition>>,
@@ -169,19 +179,6 @@ export const useExtendedArt = (id?: StringPublicKey) => {
 
   useEffect(() => {
     if (inView && id && !data) {
-      const USE_CDN = false;
-      const routeCDN = (uri: string) => {
-        let result = uri;
-        if (USE_CDN) {
-          result = uri.replace(
-            'https://arweave.net/',
-            'https://coldcdn.com/api/cdn/bronil/',
-          );
-        }
-
-        return result;
-      };
-
       if (account && account.info.data.uri) {
         const uri = routeCDN(account.info.data.uri);
 


### PR DESCRIPTION
## Change
- Metaplex will replace https://arweave.net with the host name set in `ARWEAVE_CDN`


### Notes
- Both the asset image and the metadata json stored on Arweave will be pulled through the CDN.