### PR TITLE
Fix dups and remove title classname from h1

### DIFF
--- a/js/packages/common/src/contexts/meta/loadAccounts.ts
+++ b/js/packages/common/src/contexts/meta/loadAccounts.ts
@@ -19,6 +19,7 @@ import {
   decodeMetadata,
   getAuctionExtended,
 } from '../../actions';
+import { uniqWith } from 'lodash';
 import { WhitelistedCreator } from '../../models/metaplex';
 import { Connection, PublicKey } from '@solana/web3.js';
 import {
@@ -304,7 +305,11 @@ export const loadAccounts = async (connection: Connection) => {
 
   await Promise.all(loading);
 
-  console.log('Metadata size', state.metadata.length);
+  state.metadata = uniqWith(
+    state.metadata,
+    (a: ParsedAccount<Metadata>, b: ParsedAccount<Metadata>) =>
+      a.pubkey === b.pubkey,
+  );
 
   return state;
 };

--- a/js/packages/web/src/components/ArtMinting/index.tsx
+++ b/js/packages/web/src/components/ArtMinting/index.tsx
@@ -213,9 +213,7 @@ export const ArtMinting = ({ id, onMint }: ArtMintingProps) => {
           <MetaplexOverlay visible={showCongrats}>
             <Confetti />
             <h1
-              className="title"
               style={{
-                fontSize: '3rem',
                 marginBottom: 20,
               }}
             >

--- a/js/packages/web/src/components/Notifications/index.tsx
+++ b/js/packages/web/src/components/Notifications/index.tsx
@@ -495,7 +495,7 @@ export function Notifications() {
       content={content}
       trigger="click"
     >
-      <h1 className="title" />
+      <h1 />
     </Popover>
   );
 


### PR DESCRIPTION
- Fix up dup nfts when co-creators set.
- We add our logo to the title className. It cant be used in other places or logo will appear behind the text.