### PR TITLE
Validate NFT cover images are larger than 25kb

### DIFF
--- a/js/packages/web/src/views/artCreate/index.tsx
+++ b/js/packages/web/src/views/artCreate/index.tsx
@@ -125,7 +125,7 @@ export const ArtCreateView = () => {
       );
 
       if (_nft) setNft(_nft);
-    } catch(e: any) {
+    } catch (e: any) {
       setAlertMessage(e.message)
     } finally {
       setMinting(false);
@@ -318,6 +318,7 @@ const UploadStep = (props: {
     props.files?.[0],
   );
   const [mainFile, setMainFile] = useState<File | undefined>(props.files?.[1]);
+  const [coverArtError, setCoverArtError] = useState<string>();
 
   const [customURL, setCustomURL] = useState<string>('');
   const [customURLErr, setCustomURLErr] = useState<string>('');
@@ -392,7 +393,20 @@ const UploadStep = (props: {
           fileList={coverFile ? [coverFile as any] : []}
           onChange={async info => {
             const file = info.file.originFileObj;
-            if (file) setCoverFile(file);
+
+            if (!file) {
+              return;
+            }
+
+            const sizeKB = file.size / 1024;
+
+            if (sizeKB < 25) {
+              setCoverArtError(`The file ${file.name} is too small. It is ${Math.round(10 * sizeKB) / 10}KB but should be at least 25KB.`);
+              return;
+            }
+
+            setCoverFile(file);
+            setCoverArtError(undefined);
           }}
         >
           <div className="ant-upload-drag-icon">
@@ -400,8 +414,14 @@ const UploadStep = (props: {
               Upload your cover image (PNG, JPG, GIF, SVG)
             </h3>
           </div>
-          <p className="ant-upload-text">Drag and drop, or click to browse</p>
+          {coverArtError ? (
+            <Text type="danger">{coverArtError}</Text>
+          ) : (
+            <p className="ant-upload-text">Drag and drop, or click to browse</p>
+          )}
+
         </Dragger>
+
       </Row>
       {props.attributes.properties?.category !== MetadataCategory.Image && (
         <Row
@@ -503,7 +523,9 @@ const UploadStep = (props: {
               image: coverFile?.name || '',
               animation_url: (props.attributes.properties?.category !== MetadataCategory.Image && customURL) ? customURL : mainFile && mainFile.name,
             });
-            props.setFiles([coverFile, mainFile].filter(f => f) as File[]);
+            const files = [coverFile, mainFile].filter(f => f) as File[];
+
+            props.setFiles(files);
             props.confirm();
           }}
           style={{ marginTop: 24 }}
@@ -1150,13 +1172,13 @@ const WaitingStep = (props: {
         <Steps direction="vertical" current={props.step}>
           <Step title="Minting" description="Starting Mint Process" icon={setIconForStep(props.step, 0)} />
           <Step title="Preparing Assets" icon={setIconForStep(props.step, 1)} />
-          <Step title="Signing Metadata Transaction" description="Approve the transaction from your wallet" icon={setIconForStep(props.step, 2)}  /> 
-          <Step title="Sending Transaction to Solana" description="This will take a few seconds." icon={setIconForStep(props.step, 3)} /> 
+          <Step title="Signing Metadata Transaction" description="Approve the transaction from your wallet" icon={setIconForStep(props.step, 2)} />
+          <Step title="Sending Transaction to Solana" description="This will take a few seconds." icon={setIconForStep(props.step, 3)} />
           <Step title="Waiting for Initial Confirmation" icon={setIconForStep(props.step, 4)} />
           <Step title="Waiting for Final Confirmation" icon={setIconForStep(props.step, 5)} />
           <Step title="Uploading to Arweave" icon={setIconForStep(props.step, 6)} />
           <Step title="Updating Metadata" icon={setIconForStep(props.step, 7)} />
-          <Step title="Signing Token Transaction" description="Approve the final transaction from your wallet"  icon={setIconForStep(props.step, 8)}  />
+          <Step title="Signing Token Transaction" description="Approve the final transaction from your wallet" icon={setIconForStep(props.step, 8)} />
         </Steps>
       </Card>
     </div>
@@ -1174,8 +1196,7 @@ const Congrats = (props: {
   const newTweetURL = () => {
     const params = {
       text: "I've created a new NFT artwork on Metaplex, check it out!",
-      url: `${
-        window.location.origin
+      url: `${window.location.origin
         }/#/art/${props.nft?.metadataAccount.toString()}`,
       hashtags: 'NFT,Crypto,Metaplex',
       // via: "Metaplex",


### PR DESCRIPTION
### Issue
- we have received reports of files under 25kb resulting in successful uploads to arweave but no content sized to the file. Arweave has notified us that this is an issue with the arweave to sol upload cloud function operated by Metaplex. 

### Resolution
Validate that all cover images for NFTs are larger than 25kb.

![Screenshot from 2021-10-02 13-09-44](https://user-images.githubusercontent.com/2388118/135730675-8f963ca8-f634-4e97-a73f-3514e6ba9f93.png)
