### PR TITLE
Use holaplex.rpcpool.com for connecting to mainnet

### DIFF
--- a/js/packages/common/src/contexts/connection.tsx
+++ b/js/packages/common/src/contexts/connection.tsx
@@ -42,7 +42,7 @@ export type ENV =
 export const ENDPOINTS = [
   {
     name: 'mainnet-beta' as ENV,
-    endpoint: 'https://api.metaplex.solana.com/',
+    endpoint: 'https://holaplex.rpcpool.com/',
     ChainId: ChainId.MainnetBeta,
   },
   {


### PR DESCRIPTION
### Changes
- Switch to rpc endpoint provided by Triton for accessing mainnet using dedicated rpc pool.