### PR TITLE
Load payout tickets on billing

### DIFF
--- a/js/packages/common/src/contexts/meta/loadAccounts.ts
+++ b/js/packages/common/src/contexts/meta/loadAccounts.ts
@@ -29,6 +29,7 @@ import {
   AuctionManagerV2,
   getBidRedemption,
   getPrizeTrackingTicket,
+  MAX_PAYOUT_TICKET_SIZE,
 } from '../../models/metaplex';
 import { Connection, PublicKey } from '@solana/web3.js';
 import {
@@ -184,6 +185,24 @@ export const loadAccounts = async (
   ];
 
   await Promise.all(loading);
+
+  return state;
+};
+
+export const loadPayoutTickets = async (
+  connection: Connection,
+): Promise<MetaState> => {
+  const state: MetaState = getEmptyMetaState();
+  const updateState = makeSetter(state);
+  const forEachAccount = processingAccounts(updateState);
+
+  getProgramAccounts(connection, METAPLEX_ID, {
+    filters: [
+      {
+        dataSize: MAX_PAYOUT_TICKET_SIZE,
+      },
+    ],
+  }).then(forEachAccount(processMetaplexAccounts));
 
   return state;
 };

--- a/js/packages/common/src/models/metaplex/index.ts
+++ b/js/packages/common/src/models/metaplex/index.ts
@@ -43,6 +43,7 @@ export const TOTALS = 'totals';
 export const ORIGINAL_AUTHORITY_LOOKUP_SIZE = 33;
 export const MAX_PRIZE_TRACKING_TICKET_SIZE = 1 + 32 + 8 + 8 + 8 + 50;
 export const MAX_WHITELISTED_CREATOR_SIZE = 2 + 32 + 10;
+export const MAX_PAYOUT_TICKET_SIZE = 1 + 32 + 8;
 export enum MetaplexKey {
   Uninitialized = 0,
   OriginalAuthorityLookupV1 = 1,

--- a/js/packages/web/src/views/auction/billing.tsx
+++ b/js/packages/web/src/views/auction/billing.tsx
@@ -24,6 +24,7 @@ import {
   StringPublicKey,
   toPublicKey,
   WalletSigner,
+  loadPayoutTickets
 } from '@oyster/common';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { useMeta } from '../../contexts';
@@ -46,17 +47,30 @@ export const BillingView = () => {
   const auctionView = useAuction(id);
   const connection = useConnection();
   const wallet = useWallet();
+  const { patchState } = useMeta();
+  const [loadingBilling, setLoadingBilling] = useState<boolean>();
   const mint = useMint(auctionView?.auction.info.tokenMint);
 
-  return auctionView && wallet && connection && mint ? (
+  useEffect(() => {
+    (async () => {
+      const billingState = await loadPayoutTickets(connection);
+      
+      patchState(billingState);
+      setLoadingBilling(false);
+    })()
+  }, [loadingBilling]);
+
+  return loadingBilling || !auctionView || !wallet || !connection || !mint ? (
+    <div className="app-section--loading">
+      <Spin indicator={<LoadingOutlined />} />
+    </div>
+  ) : (
     <InnerBillingView
       auctionView={auctionView}
       connection={connection}
       wallet={wallet}
       mint={mint}
     />
-  ) : (
-    <Spin indicator={<LoadingOutlined />} />
   );
 };
 


### PR DESCRIPTION
### Changes
In the recent data fetching refactor payout tickets were left out. This updates billing to fetch all payout tickets for metaplex to start. It's quick and is what is in upstream today. (or as of the introduction of auction cache)