### PR TITLE
[Fix] Don't cache 429 image lookups

### DIFF
--- a/js/packages/web/src/hooks/useArt.ts
+++ b/js/packages/web/src/hooks/useArt.ts
@@ -109,7 +109,7 @@ export const useCachedImage = (uri: string, cacheMesh?: boolean) => {
 
         blob = await response.blob();
 
-        if (blob.size === 0) {
+        if (blob.size === 0 || !response.ok) {
           throw new Error('No content');
         }
       } catch {


### PR DESCRIPTION
![Screenshot from 2021-10-21 14-28-58](https://user-images.githubusercontent.com/2388118/138359661-80fd948b-292f-43b9-9521-a550084bcce5.png)


### Changes
- Throw a now content error to trigger a request of the image asset without cache. 

### Issue

IPFS returned 429 responses while visiting dev which became cached.