### PR TITLE
[Fix] If Upload Endpoint Fails Stop The Mint

### DIFF
--- a/js/packages/web/src/actions/nft.tsx
+++ b/js/packages/web/src/actions/nft.tsx
@@ -148,6 +148,11 @@ export const mintNFT = async (
       method: "POST",
       body: fileDataForm,
     })
+
+  if (!uploadResponse.ok) {
+    throw new Error("Unable to upload files to IPFS. Please wait a moment and try again.")
+  }
+
   const uploadedFilePins: { files: PinFileResponse[] } = await uploadResponse.json()
   // add files to properties
   // first image is added as image
@@ -184,6 +189,11 @@ export const mintNFT = async (
       method: "POST",
       body: metaDataFileForm,
     })
+
+  if (!metaDataUploadResponse.ok) {
+    throw new Error("Unable to upload NFT metadata to IPFS. Please wait a moment and try again.")
+  }
+
   const uploadedMetaDataPinResponse = await metaDataUploadResponse.json()
   const uploadedMetaDataPin = uploadedMetaDataPinResponse.files[0]
 
@@ -317,7 +327,7 @@ export const prepPayForFilesTxn = async (
         fromPubkey: wallet.publicKey,
         toPubkey: AR_SOL_HOLDER_ID,
         lamports: 2300000 // 0.0023 SOL per file (paid to arweave)
-          // await getAssetCostToStore(files),
+        // await getAssetCostToStore(files),
       }),
     );
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2388118/138784315-1bd467a6-656d-4452-b4c5-d2732a20ad57.png)


### Changes
Throw an error that exists minting before submitting to Solana when the upload endpoint fails.