### PR TITLE
Fix(auction-caches): Out of order auction caches

### DIFF
--- a/js/packages/common/src/models/metaplex/setStoreIndex.ts
+++ b/js/packages/common/src/models/metaplex/setStoreIndex.ts
@@ -1,8 +1,4 @@
-import {
-  SYSVAR_CLOCK_PUBKEY,
-  SYSVAR_RENT_PUBKEY,
-  TransactionInstruction,
-} from '@solana/web3.js';
+import { SYSVAR_RENT_PUBKEY, TransactionInstruction } from '@solana/web3.js';
 import BN from 'bn.js';
 import { serialize } from 'borsh';
 
@@ -77,6 +73,7 @@ export async function setStoreIndex(
       isWritable: false,
     });
   }
+
   instructions.push(
     new TransactionInstruction({
       keys,

--- a/js/packages/web/src/actions/cacheAuctionIndexer.ts
+++ b/js/packages/web/src/actions/cacheAuctionIndexer.ts
@@ -20,6 +20,7 @@ export async function cacheAuctionIndexer(
   auctionManager: StringPublicKey,
   tokenMints: StringPublicKey[],
   storeIndexer: ParsedAccount<StoreIndexer>[],
+  offset: number,
   skipCache?: boolean,
 ): Promise<{
   instructions: TransactionInstruction[][];
@@ -42,10 +43,11 @@ export async function cacheAuctionIndexer(
     tokenMints,
   );
 
-  let above =
-    storeIndexer.length == 0
+  const above =
+    storeIndexer.length === 0
       ? undefined
-      : storeIndexer[0].info.auctionCaches[0];
+      : storeIndexer[0].info.auctionCaches[offset];
+  const below = storeIndexer[0].info.auctionCaches[offset - 1];
 
   const storeIndexKey = await getStoreIndexer(0);
   await setStoreIndex(
@@ -53,9 +55,9 @@ export async function cacheAuctionIndexer(
     auctionCache,
     payer,
     new BN(0),
-    new BN(0),
+    new BN(offset),
     instructions,
-    undefined,
+    below,
     above,
   );
 
@@ -85,8 +87,8 @@ async function propagateIndex(
 
   const payer = wallet.publicKey.toBase58();
 
-  let currSignerBatch: Array<Keypair[]> = [];
-  let currInstrBatch: Array<TransactionInstruction[]> = [];
+  const currSignerBatch: Array<Keypair[]> = [];
+  const currInstrBatch: Array<TransactionInstruction[]> = [];
 
   let indexSigners: Keypair[] = [];
   let indexInstructions: TransactionInstruction[] = [];
@@ -163,8 +165,8 @@ async function createAuctionCache(
 
   const payer = wallet.publicKey.toBase58();
 
-  let currSignerBatch: Array<Keypair[]> = [];
-  let currInstrBatch: Array<TransactionInstruction[]> = [];
+  const currSignerBatch: Array<Keypair[]> = [];
+  const currInstrBatch: Array<TransactionInstruction[]> = [];
 
   let cacheSigners: Keypair[] = [];
   let cacheInstructions: TransactionInstruction[] = [];

--- a/js/packages/web/src/views/admin/index.tsx
+++ b/js/packages/web/src/views/admin/index.tsx
@@ -475,7 +475,7 @@ function InnerAdminView({
                 loading={cachingAuctions}
                 onClick={async () => {
                   setCachingAuctions(true);
-
+                  
                   await cacheAllAuctions(
                     wallet,
                     connection,


### PR DESCRIPTION
### Issue
The metaplex program ensures that the active action cache isn't older than the latest cached auction. This prevents users from completing the caching process when 1 cache was created but not placed in the index. The current code only assumes the cache should be placed in the first slot of the list but it should actually be somewhere deeper in the list.

### Fix
Scan the currently cached auctions to find the first index where the missed auction cache is older than the current cache being checked. This offset is where the cache should be set. The program supports setting in offset other than the 0 slot which this takes advantage of.