### PR TITLE
[Fix] Handle Initial Cache Creation

### DIFF
--- a/js/packages/common/src/contexts/connection.tsx
+++ b/js/packages/common/src/contexts/connection.tsx
@@ -603,7 +603,7 @@ export async function sendSignedTransaction({
   return { txid, slot };
 }
 
-async function simulateTransaction(
+export async function simulateTransaction(
   connection: Connection,
   transaction: Transaction,
   commitment: Commitment,

--- a/js/packages/web/src/actions/cacheAllAuctions.ts
+++ b/js/packages/web/src/actions/cacheAllAuctions.ts
@@ -47,17 +47,18 @@ export async function cacheAllAuctions(
     const auctionCache = auctionCaches[auctionCachePubkey];
     const cacheExists = !!auctionCache;
     const activeIndex = storeIndex[0];
-    const offset = findIndex(activeIndex.info.auctionCaches, pubkey => {
-      const cache = auctionCaches[pubkey];
+    let offset = 0;
 
-      if (!cacheExists) {
-        return true;
-      }
+    if (activeIndex && cacheExists) {
+      offset = findIndex(activeIndex.info.auctionCaches, pubkey => {
+        const cache = auctionCaches[pubkey];
 
-      return (
-        auctionCache.info.timestamp.toNumber() > cache.info.timestamp.toNumber()
-      );
-    });
+        return (
+          auctionCache.info.timestamp.toNumber() >
+          cache.info.timestamp.toNumber()
+        );
+      });
+    }
 
     const { instructions, signers } = await cacheAuctionIndexer(
       wallet,

--- a/js/packages/web/src/actions/cacheAuctionIndexer.ts
+++ b/js/packages/web/src/actions/cacheAuctionIndexer.ts
@@ -43,11 +43,13 @@ export async function cacheAuctionIndexer(
     tokenMints,
   );
 
-  const above =
-    storeIndexer.length === 0
-      ? undefined
-      : storeIndexer[0].info.auctionCaches[offset];
-  const below = storeIndexer[0].info.auctionCaches[offset - 1];
+  let above = undefined;
+  let below = undefined;
+
+  if (storeIndexer.length > 0) {
+    above = storeIndexer[0].info.auctionCaches[offset];
+    below = below = storeIndexer[0].info.auctionCaches[offset - 1];
+  }
 
   const storeIndexKey = await getStoreIndexer(0);
   await setStoreIndex(

--- a/js/packages/web/src/views/admin/index.tsx
+++ b/js/packages/web/src/views/admin/index.tsx
@@ -470,7 +470,7 @@ function InnerAdminView({
             Activate your storefront listing caches by pressing &ldquo;build
             cache&rdquo;. This will reduce page load times for your listings.
             Your storefront will start looking up listing using the cache on
-            November 3rd. To preview the speed improvement visit the Holaplex{' '}
+            November 17th. To preview the speed improvement visit the Holaplex{' '}
             <a
               rel="noopener noreferrer"
               target="_blank"

--- a/js/packages/web/src/views/home/auctionList.tsx
+++ b/js/packages/web/src/views/home/auctionList.tsx
@@ -47,7 +47,7 @@ export const AuctionListView = () => {
       {showCacheAuctionsAlert && (
         <Alert
           message="Attention Store Owner"
-          className="app-alert-banner"
+          className="app-alert-banner metaplex-spacing-bottom-lg"
           description={
             <p>
               Make your storefront faster by enabling listing caches.{' '}
@@ -60,7 +60,7 @@ export const AuctionListView = () => {
               >
                 video
               </a>{' '}
-              for more details and a walkthrough. On November 3rd storefronts
+              for more details and a walkthrough. On November 17rd storefronts
               will start reading from the cache for listings. All new listing
               are generating a cache account.
             </p>


### PR DESCRIPTION
### Issue
The previously deployed patch to handle setting auction caches that have been placed out of order did not account for the initial condition of no storeIndexer.

### Changes
- When no store indexer or auction cache doesn't already exist set the offset to 0. This puts it as the latest auction.