### PR TITLE
Increate timeout on transaction confirmation to 30sec from 15sec

### DIFF
--- a/js/packages/common/src/contexts/connection.tsx
+++ b/js/packages/common/src/contexts/connection.tsx
@@ -515,7 +515,7 @@ export const getUnixTs = () => {
   return new Date().getTime() / 1000;
 };
 
-const DEFAULT_TIMEOUT = 15000;
+const DEFAULT_TIMEOUT = 30000;
 
 export async function sendSignedTransaction({
   signedTransaction,

--- a/js/packages/web/src/views/auctionCreate/waitingStep.tsx
+++ b/js/packages/web/src/views/auctionCreate/waitingStep.tsx
@@ -11,7 +11,7 @@ export const WaitingStep = (props: {
     const func = async () => {
       const inte = setInterval(
         () => setProgress(prog => Math.min(prog + 1, 99)),
-        600,
+        120,
       );
       await props.createAuction();
       clearInterval(inte);
@@ -24,7 +24,7 @@ export const WaitingStep = (props: {
     <div className="auction-progress-indicator">
       <Progress type="circle" percent={progress} />
       <div>Your creation is being listed with Metaplex...</div>
-      <div>This can take up to 30 seconds.</div>
+      <div>This can take up to 90 seconds.</div>
     </div>
   );
 };


### PR DESCRIPTION
### Changes
- RPC provider recommended increasing the timeout on success tracking past 15sec. 