### PR TITLE
Fix Initial Bid and Adding More to Bid Validations

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -293,8 +293,8 @@ export const AuctionCard = ({
           mintInfo,
         )
       : isStarted && bids.length > 0 ? parseFloat(formatTokenAmount(bids[0].info.lastBid.toNumber(), mintInfo)) : 9999999) + (tickSize && hasBids ? (tickSize.toNumber() / LAMPORTS_PER_SOL) : 0);
-  const biddingPower = balance.balance + (auctionView.myBidderMetadata ? auctionView.myBidderMetadata.info.lastBid.toNumber() : 0);
-
+  const biddingPower = balance.balance + (auctionView.myBidderMetadata ? (auctionView.myBidderMetadata.info.lastBid.toNumber() / LAMPORTS_PER_SOL) : 0);
+  
   const notEnoughFundsToBid = value && (value > biddingPower);
   const invalidBid =
     tickSizeInvalid ||
@@ -804,7 +804,7 @@ export const AuctionCard = ({
           )}
           {notEnoughFundsToBid && (
             <Text type="danger">
-              You do not have enough funds to fulfill the bid. Your current bidding power is ${biddingPower}.
+              You do not have enough funds to fulfill the bid. Your current bidding power is {biddingPower} SOL.
             </Text>
           )}
           {tickSizeInvalid && tickSize && (

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -284,15 +284,18 @@ export const AuctionCard = ({
     auctionView.auctionManager.participationConfig?.fixedPrice || 0;
   const participationOnly =
     auctionView.auctionManager.numWinners.toNumber() === 0;
-
+  
+  const hasBids = bids.length > 0;
   const minBid =
     (isUpcoming || bids.length === 0
       ? fromLamports(
           participationOnly ? participationFixedPrice : priceFloor,
           mintInfo,
         )
-      : isStarted && bids.length > 0 ? parseFloat(formatTokenAmount(bids[0].info.lastBid.toNumber(), mintInfo)) : 9999999) + (tickSize ? (tickSize.toNumber() / LAMPORTS_PER_SOL) : 0);
-  const notEnoughFundsToBid = value && (value > balance.balance);
+      : isStarted && bids.length > 0 ? parseFloat(formatTokenAmount(bids[0].info.lastBid.toNumber(), mintInfo)) : 9999999) + (tickSize && hasBids ? (tickSize.toNumber() / LAMPORTS_PER_SOL) : 0);
+  const biddingPower = balance.balance + (auctionView.myBidderMetadata ? auctionView.myBidderMetadata.info.lastBid.toNumber() : 0);
+
+  const notEnoughFundsToBid = value && (value > biddingPower);
   const invalidBid =
     tickSizeInvalid ||
     notEnoughFundsToBid ||
@@ -801,7 +804,7 @@ export const AuctionCard = ({
           )}
           {notEnoughFundsToBid && (
             <Text type="danger">
-              You do not have enough funds to fulfill the bid.
+              You do not have enough funds to fulfill the bid. Your current bidding power is ${biddingPower}.
             </Text>
           )}
           {tickSizeInvalid && tickSize && (


### PR DESCRIPTION
### Changes
- Only enforce tick size if past the initial bid.
- Calculate bidding power based on the user's current bid plus what is in their wallet. Not just the balance in the wallet.

![Screenshot from 2021-11-13 16-41-44](https://user-images.githubusercontent.com/2388118/141663366-d4cd3eb0-cb47-4a77-a8c4-6738506f6efc.png)
