### PR TITLE
[Hot Fix] Hide Vortex duplicate auctions

### DIFF
--- a/js/packages/common/src/contexts/meta/processAuctions.ts
+++ b/js/packages/common/src/contexts/meta/processAuctions.ts
@@ -15,12 +15,16 @@ import { AUCTION_ID, pubkeyToString } from '../../utils';
 import { ParsedAccount } from '../accounts';
 import { cache } from '../accounts';
 import { CheckAccountFunc, ProcessAccountsFunc } from './types';
+const AUCTION_BLACK_LIST = [
+  '9zcrbzSmBPdDjAGYXkfufP2wy1kbHKac8UYLBmHpbuYy',
+  'DzR58tU6ZXx2sMBVjaL2dhNF9SL9qd42eYXLbtu5qcCx',
+];
 
 export const processAuctions: ProcessAccountsFunc = async (
   { account, pubkey },
   setter,
 ) => {
-  if (!isAuctionAccount(account)) return;
+  if (!isAuctionAccount(account) || isOnBlackList(pubkey)) return;
 
   try {
     const parsedAccount = cache.add(
@@ -90,6 +94,8 @@ export const processAuctions: ProcessAccountsFunc = async (
     // add type as first byte for easier deserialization
   }
 };
+
+const isOnBlackList = (pubkey: string) => AUCTION_BLACK_LIST.includes(pubkey);
 
 const isAuctionAccount: CheckAccountFunc = account =>
   pubkeyToString(account?.owner) === AUCTION_ID;

--- a/js/packages/web/src/hooks/useAuctionManagersToCache.ts
+++ b/js/packages/web/src/hooks/useAuctionManagersToCache.ts
@@ -25,7 +25,8 @@ export const useAuctionManagersToCache = (): AuctionCacheStatus => {
       .filter(
         a =>
           a.info.store == storeAddress &&
-          a.info.key === MetaplexKey.AuctionManagerV2,
+          a.info.key === MetaplexKey.AuctionManagerV2 &&
+          auctions[a.info.auction],
       )
       .sort((a, b) =>
         (auctions[b.info.auction].info.endedAt || new BN(Date.now() / 1000))

--- a/js/packages/web/src/hooks/useAuctions.ts
+++ b/js/packages/web/src/hooks/useAuctions.ts
@@ -81,13 +81,13 @@ export function useCompactAuctions(): AuctionViewCompact[] {
   const { auctionManagersByAuction, auctions, vaults } = useMeta();
 
   const result = useMemo(() => {
-    return Object.values(auctionManagersByAuction).map(
-      (am: ParsedAccount<AuctionManagerV1 | AuctionManagerV2>) => ({
+    return Object.values(auctionManagersByAuction)
+      .filter(am => auctions[am.info.auction])
+      .map((am: ParsedAccount<AuctionManagerV1 | AuctionManagerV2>) => ({
         auctionManager: am,
         auction: auctions[am.info.auction],
         vault: vaults[am.info.vault],
-      }),
-    );
+      }));
   }, [auctions, auctionManagersByAuction, vaults]);
 
   return result;
@@ -117,7 +117,7 @@ export function useCachedRedemptionKeysByWallet() {
     (async () => {
       const temp: CachedRedemptionKeys = {};
       await createPipelineExecutor(
-        auctions.values(),
+        auctions.filter(a => a).values(),
         async auction => {
           if (!cachedRedemptionKeys[auction.pubkey]) {
             await getBidderKeys(auction.pubkey, publicKey.toBase58()).then(
@@ -254,7 +254,9 @@ export const useInfiniteScrollAuctions = () => {
     (async () => {
       const storeAuctionManagers = Object.values(
         auctionManagersByAuction,
-      ).filter(am => am.info.store === storeAddress);
+      ).filter(
+        am => am.info.store === storeAddress && auctions[am.info.auction],
+      );
       const initializedAuctions = storeAuctionManagers
         .map(am => auctions[am.info.auction])
         .filter(a => a.info.state > 0);


### PR DESCRIPTION
### Changes
- Black list of auctions to skip processing so they don't display on the storefronts. This is a specific patch for vortexmonkey that reminted and listed with old listings going through.
- 