### PR TITLE
Format Numbers properly

### DIFF
--- a/js/packages/common/src/utils/utils.ts
+++ b/js/packages/common/src/utils/utils.ts
@@ -210,7 +210,7 @@ export const tryParseKey = (key: string): PublicKey | null => {
   }
 };
 
-export const formatAmount = (val: number) => val.toLocaleString();
+export const formatAmount = (val: number): string => val.toLocaleString();
 
 export function formatTokenAmount(
   account?: TokenAccount | number | BN,

--- a/js/packages/common/src/utils/utils.ts
+++ b/js/packages/common/src/utils/utils.ts
@@ -210,25 +210,7 @@ export const tryParseKey = (key: string): PublicKey | null => {
   }
 };
 
-const SI_SYMBOL = ['', 'k', 'M', 'G', 'T', 'P', 'E'] as const;
-
-const abbreviateNumber = (number: number, precision: number) => {
-  const tier = (Math.log10(number) / 3) | 0;
-  let scaled = number;
-  const suffix = SI_SYMBOL[tier];
-  if (tier !== 0) {
-    const scale = Math.pow(10, tier * 3);
-    scaled = number / scale;
-  }
-
-  return scaled.toFixed(precision) + suffix;
-};
-
-export const formatAmount = (
-  val: number,
-  precision: number = 2,
-  abbr: boolean = true,
-) => (abbr ? abbreviateNumber(val, precision) : val.toFixed(precision));
+export const formatAmount = (val: number) => val.toLocaleString();
 
 export function formatTokenAmount(
   account?: TokenAccount | number | BN,
@@ -236,8 +218,6 @@ export function formatTokenAmount(
   rate: number = 1.0,
   prefix = '',
   suffix = '',
-  precision = 2,
-  abbr = false,
 ): string {
   if (!account) {
     return '';
@@ -245,8 +225,6 @@ export function formatTokenAmount(
 
   return `${[prefix]}${formatAmount(
     fromLamports(account, mint, rate),
-    precision,
-    abbr,
   )}${suffix}`;
 }
 

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -749,7 +749,7 @@ export const AuctionCard = ({
                 <AmountLabel
                   title="in your wallet"
                   displaySOL={true}
-                  amount={formatAmount(balance.balance, 2)}
+                  amount={formatAmount(balance.balance)}
                   customPrefix={
                     <Identicon
                       size={24}


### PR DESCRIPTION
- refactor number formatting to allow for amounts below 1

The code this replaces would show small numbers as 1, this puts anything below .001 as 0. 