### PR TITLE
Fix: Auction funds distribution

### DIFF
--- a/js/packages/common/src/contexts/meta/processMetaplexAccounts.ts
+++ b/js/packages/common/src/contexts/meta/processMetaplexAccounts.ts
@@ -148,7 +148,7 @@ export const processMetaplexAccounts: ProcessAccountsFunc = async (
       }
     }
 
-    if (isSafetyDepositConfigV1Account(account)) {
+    if (isSafetyDepositConfigV2Account(account)) {
       const config = decodeSafetyDepositConfig(account.data);
       const parsedAccount: ParsedAccount<SafetyDepositConfigV2> = {
         pubkey,
@@ -221,8 +221,8 @@ const isPrizeTrackingTicketV1Account = (account: AccountInfo<Buffer>) =>
 const isStoreV1Account = (account: AccountInfo<Buffer>) =>
   account.data[0] === MetaplexKey.StoreV1;
 
-const isSafetyDepositConfigV1Account = (account: AccountInfo<Buffer>) =>
-  account.data[0] === MetaplexKey.SafetyDepositConfigV1;
+const isSafetyDepositConfigV2Account = (account: AccountInfo<Buffer>) =>
+  account.data[0] === MetaplexKey.SafetyDepositConfigV2;
 
 const isWhitelistedCreatorV1Account = (account: AccountInfo<Buffer>) =>
   account.data[0] === MetaplexKey.WhitelistedCreatorV1;

--- a/js/packages/common/src/contexts/meta/processMetaplexAccounts.ts
+++ b/js/packages/common/src/contexts/meta/processMetaplexAccounts.ts
@@ -17,7 +17,7 @@ import {
   decodePrizeTrackingTicket,
   BidRedemptionTicketV2,
   decodeSafetyDepositConfig,
-  SafetyDepositConfig,
+  SafetyDepositConfigV2,
   decodeAuctionCache,
   AuctionCache,
   decodeStoreIndexer,
@@ -150,7 +150,7 @@ export const processMetaplexAccounts: ProcessAccountsFunc = async (
 
     if (isSafetyDepositConfigV1Account(account)) {
       const config = decodeSafetyDepositConfig(account.data);
-      const parsedAccount: ParsedAccount<SafetyDepositConfig> = {
+      const parsedAccount: ParsedAccount<SafetyDepositConfigV2> = {
         pubkey,
         account,
         info: config,

--- a/js/packages/common/src/contexts/meta/types.ts
+++ b/js/packages/common/src/contexts/meta/types.ts
@@ -19,7 +19,7 @@ import {
   BidRedemptionTicketV2,
   PayoutTicket,
   PrizeTrackingTicket,
-  SafetyDepositConfig,
+  SafetyDepositConfigV2,
   Store,
   StoreIndexer,
   WhitelistedCreator,
@@ -50,7 +50,7 @@ export interface MetaState {
   >;
   safetyDepositConfigsByAuctionManagerAndIndex: Record<
     string,
-    ParsedAccount<SafetyDepositConfig>
+    ParsedAccount<SafetyDepositConfigV2>
   >;
   bidRedemptionV2sByAuctionManagerAndWinningIndex: Record<
     string,

--- a/js/packages/common/src/models/metaplex/validateSafetyDepositBoxV3.ts
+++ b/js/packages/common/src/models/metaplex/validateSafetyDepositBoxV3.ts
@@ -10,13 +10,13 @@ import {
   getAuctionWinnerTokenTypeTracker,
   getOriginalAuthority,
   getSafetyDepositConfig,
-  SafetyDepositConfig,
+  SafetyDepositConfigV2,
   SCHEMA,
-  ValidateSafetyDepositBoxV2Args,
+  ValidateSafetyDepositBoxV3Args,
 } from '.';
 import { programIds, toPublicKey, StringPublicKey } from '../../utils';
 
-export async function validateSafetyDepositBoxV2(
+export async function validateSafetyDepositBoxV3(
   vault: StringPublicKey,
   metadata: StringPublicKey,
   safetyDepositBox: StringPublicKey,
@@ -29,7 +29,7 @@ export async function validateSafetyDepositBoxV2(
   edition: StringPublicKey,
   whitelistedCreator: StringPublicKey | undefined,
   store: StringPublicKey,
-  safetyDepositConfig: SafetyDepositConfig,
+  safetyDepositConfig: SafetyDepositConfigV2,
 ) {
   const PROGRAM_IDS = programIds();
 
@@ -49,7 +49,7 @@ export async function validateSafetyDepositBoxV2(
     auctionManagerKey,
   );
 
-  const value = new ValidateSafetyDepositBoxV2Args(safetyDepositConfig);
+  const value = new ValidateSafetyDepositBoxV3Args(safetyDepositConfig);
   const data = Buffer.from(serialize(SCHEMA, value));
 
   const keys = [

--- a/js/packages/common/src/utils/ids.ts
+++ b/js/packages/common/src/utils/ids.ts
@@ -75,6 +75,6 @@ export const AUCTION_ID =
   'auctxRXPeJoc4817jDhf4HbjnhEcr1cCXenosMhK5R8' as StringPublicKey;
 
 export const METAPLEX_ID =
-  'p1exdMJcjVao65QdewkaZRUnU6VPSXhus9n2GzWfh98' as StringPublicKey;
+  'hkevC3CDmdphvvg1zgxfBA8Z18zWXH4g34cSp1zX6dc' as StringPublicKey;
 
 export const SYSTEM = new PublicKey('11111111111111111111111111111111');

--- a/js/packages/web/src/actions/addTokensToVault.ts
+++ b/js/packages/web/src/actions/addTokensToVault.ts
@@ -6,8 +6,8 @@ import {
   StringPublicKey,
   toPublicKey,
   WalletSigner,
+  SafetyDepositConfigV2,
 } from '@oyster/common';
-import { SafetyDepositConfig } from '@oyster/common/dist/lib/models/metaplex/index';
 import { approve } from '@oyster/common/dist/lib/models/account';
 import { createTokenAccount } from '@oyster/common/dist/lib/actions/account';
 import {
@@ -27,7 +27,7 @@ export interface SafetyDepositInstructionTemplate {
     amount: BN;
   };
   draft: SafetyDepositDraft;
-  config: SafetyDepositConfig;
+  config: SafetyDepositConfigV2;
 }
 
 const BATCH_SIZE = 1;

--- a/js/packages/web/src/actions/createAuctionManager.ts
+++ b/js/packages/web/src/actions/createAuctionManager.ts
@@ -26,6 +26,7 @@ import {
   toPublicKey,
   WalletSigner,
 } from '@oyster/common';
+import { validateSafetyDepositBoxV3 } from '@oyster/common/dist/lib/models/metaplex/validateSafetyDepositBoxV3';
 import { WalletNotConnectedError } from '@solana/wallet-adapter-base';
 import { AccountLayout, Token } from '@solana/spl-token';
 import BN from 'bn.js';
@@ -38,7 +39,7 @@ import {
   AmountRange,
   ParticipationConfigV2,
   TupleNumericType,
-  SafetyDepositConfig,
+  SafetyDepositConfigV2,
   ParticipationStateV2,
   StoreIndexer,
 } from '@oyster/common/dist/lib/models/metaplex/index';
@@ -56,7 +57,6 @@ import { deprecatedCreateReservationListForTokens } from './deprecatedCreateRese
 import { deprecatedPopulatePrintingTokens } from './deprecatedPopulatePrintingTokens';
 import { setVaultAndAuctionAuthorities } from './setVaultAndAuctionAuthorities';
 import { markItemsThatArentMineAsSold } from './markItemsThatArentMineAsSold';
-import { validateSafetyDepositBoxV2 } from '@oyster/common/dist/lib/models/metaplex/validateSafetyDepositBoxV2';
 import { initAuctionManagerV2 } from '@oyster/common/dist/lib/models/metaplex/initAuctionManagerV2';
 import { cacheAuctionIndexer } from './cacheAuctionInIndexer';
 import { SetStateAction, Dispatch } from 'react';
@@ -411,7 +411,7 @@ async function buildSafetyDepositArray(
                 ),
               ),
       },
-      config: new SafetyDepositConfig({
+      config: new SafetyDepositConfigV2({
         directArgs: {
           auctionManager: SystemProgram.programId.toBase58(),
           order: new BN(i),
@@ -425,6 +425,7 @@ async function buildSafetyDepositArray(
           winningConfigType: s.winningConfigType,
           participationConfig: null,
           participationState: null,
+          primarySaleHappened: false,
         },
       }),
       draft: s,
@@ -445,7 +446,7 @@ async function buildSafetyDepositArray(
     ]
       .sort()
       .reverse()[0];
-    const config = new SafetyDepositConfig({
+    const config = new SafetyDepositConfigV2({
       directArgs: {
         auctionManager: SystemProgram.programId.toBase58(),
         order: new BN(safetyDeposits.length),
@@ -462,6 +463,7 @@ async function buildSafetyDepositArray(
         participationState: new ParticipationStateV2({
           collectedToAcceptPayment: new BN(0),
         }),
+        primarySaleHappened: false,
       },
     });
 
@@ -728,7 +730,7 @@ async function validateBoxes(
         )
       : undefined;
 
-    await validateSafetyDepositBoxV2(
+    await validateSafetyDepositBoxV3(
       vault,
       safetyDeposits[i].draft.metadata.pubkey,
       safetyDepositBox,

--- a/js/packages/web/src/hooks/useAuctions.ts
+++ b/js/packages/web/src/hooks/useAuctions.ts
@@ -26,10 +26,10 @@ import {
   BidRedemptionTicket,
   BidRedemptionTicketV2,
   getBidderKeys,
-  MetaplexKey,
-  SafetyDepositConfig,
+  SafetyDepositConfigV2,
   WinningConfigType,
   AuctionViewItem,
+  MetaplexKey,
 } from '@oyster/common';
 import { merge, take, drop } from 'lodash';
 import { Connection } from '@solana/web3.js';
@@ -474,7 +474,7 @@ export function processAccountsIntoAuctionView(
   vaults: Record<string, ParsedAccount<Vault>>,
   safetyDepositConfigsByAuctionManagerAndIndex: Record<
     string,
-    ParsedAccount<SafetyDepositConfig>
+    ParsedAccount<SafetyDepositConfigV2>
   >,
   masterEditionsByPrintingMint: Record<string, ParsedAccount<MasterEditionV1>>,
   masterEditionsByOneTimeAuthMint: Record<
@@ -529,7 +529,7 @@ export function processAccountsIntoAuctionView(
     const vault = vaults[auctionManagerInstance.info.vault];
     const auctionManagerKey = auctionManagerInstance.pubkey;
 
-    const safetyDepositConfigs: ParsedAccount<SafetyDepositConfig>[] =
+    const safetyDepositConfigs: ParsedAccount<SafetyDepositConfigV2>[] =
       buildListWhileNonZero(
         safetyDepositConfigsByAuctionManagerAndIndex,
         auctionManagerKey,

--- a/rust/kevin.sh
+++ b/rust/kevin.sh
@@ -1,0 +1,4 @@
+rm -rf ./dist/metaplex/metaplex-keypair.json
+rm -rf metaplex.so
+cargo build-bpf --manifest-path=./metaplex/program/Cargo.toml --bpf-out-dir=./dist/metaplex
+solana airdrop 5 && solana program deploy ./dist/metaplex/metaplex.so --program-id ./dist/metaplex/hkevC3CDmdphvvg1zgxfBA8Z18zWXH4g34cSp1zX6dc.json

--- a/rust/metaplex/program/src/instruction.rs
+++ b/rust/metaplex/program/src/instruction.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         deprecated_state::AuctionManagerSettingsV1,
-        state::{SafetyDepositConfig, TupleNumericType, PREFIX},
+        state::{SafetyDepositConfig, SafetyDepositConfigV2, TupleNumericType, PREFIX},
     },
     borsh::{BorshDeserialize, BorshSerialize},
     metaplex_token_metadata::state::EDITION_MARKER_BIT_SIZE,
@@ -665,6 +665,34 @@ pub enum MetaplexInstruction {
     ///   7. `[]` Rent sysvar
     ///   8. `[]` Clock sysvar
     SetAuctionCache,
+
+    /// NOTE: Requires an AuctionManagerV2.
+    ///
+    /// Validates that a given safety deposit box has in it contents that match the given SafetyDepositConfig, and creates said config.
+    /// A stateful call, this will error out if you call it a second time after validation has occurred.
+    ///   0. `[writable]` Uninitialized Safety deposit config, pda of seed ['metaplex', program id, auction manager key, safety deposit key]
+    ///   1. `[writable]` AuctionWinnerTokenTypeTracker, pda of seed ['metaplex', program id, auction manager key, 'totals']
+    ///   2. `[writable]` Auction manager
+    ///   3. `[writable]` Metadata account
+    ///   4. `[writable]` Original authority lookup - unallocated uninitialized pda account with seed ['metaplex', auction key, metadata key]
+    ///                   We will store original authority here to return it later.
+    ///   5. `[]` A whitelisted creator entry for the store of this auction manager pda of ['metaplex', store key, creator key]
+    ///   where creator key comes from creator list of metadata, any will do
+    ///   6. `[]` The auction manager's store key
+    ///   7. `[]` Safety deposit box account
+    ///   8. `[]` Safety deposit box storage account where the actual nft token is stored
+    ///   9. `[]` Mint account of the token in the safety deposit box
+    ///   10. `[]` Edition OR MasterEdition record key
+    ///           Remember this does not need to be an existing account (may not be depending on token), just is a pda with seed
+    ///            of ['metadata', program id, Printing mint id, 'edition']. - remember PDA is relative to token metadata program.
+    ///   11. `[]` Vault account
+    ///   12. `[signer]` Authority
+    ///   13. `[signer optional]` Metadata Authority - Signer only required if doing a full ownership txfer
+    ///   14. `[signer]` Payer
+    ///   15. `[]` Token metadata program
+    ///   16. `[]` System
+    ///   17. `[]` Rent sysvar
+    ValidateSafetyDepositBoxV3(SafetyDepositConfigV2),
 }
 
 /// Creates an DeprecatedInitAuctionManager instruction

--- a/rust/metaplex/program/src/lib.rs
+++ b/rust/metaplex/program/src/lib.rs
@@ -10,4 +10,4 @@ pub mod utils;
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;
 
-solana_program::declare_id!("p1exdMJcjVao65QdewkaZRUnU6VPSXhus9n2GzWfh98");
+solana_program::declare_id!("hkevC3CDmdphvvg1zgxfBA8Z18zWXH4g34cSp1zX6dc");

--- a/rust/metaplex/program/src/processor.rs
+++ b/rust/metaplex/program/src/processor.rs
@@ -22,6 +22,7 @@ use {
     solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},
     start_auction::process_start_auction,
     validate_safety_deposit_box_v2::process_validate_safety_deposit_box_v2,
+    validate_safety_deposit_box_v3::process_validate_safety_deposit_box_v3,
     withdraw_master_edition::process_withdraw_master_edition,
 };
 
@@ -46,6 +47,7 @@ pub mod set_whitelisted_creator;
 pub mod start_auction;
 pub mod validate_safety_deposit_box_v2;
 pub mod withdraw_master_edition;
+pub mod validate_safety_deposit_box_v3;
 
 pub fn process_instruction<'a>(
     program_id: &'a Pubkey,
@@ -160,6 +162,10 @@ pub fn process_instruction<'a>(
         MetaplexInstruction::SetAuctionCache => {
             msg!("Instruction: Set Auction Cache");
             process_set_auction_cache(program_id, accounts)
+        }
+        MetaplexInstruction::ValidateSafetyDepositBoxV3(safety_deposit_config) => {
+            msg!("Instruction: Validate Safety Deposit Box V3");
+            process_validate_safety_deposit_box_v3(program_id, accounts, safety_deposit_config)
         }
     }
 }

--- a/rust/metaplex/program/src/processor/empty_payment_account.rs
+++ b/rust/metaplex/program/src/processor/empty_payment_account.rs
@@ -5,7 +5,7 @@ use {
         error::MetaplexError,
         instruction::EmptyPaymentAccountArgs,
         state::{
-            get_auction_manager, AuctionManager, Key, PayoutTicket, SafetyDepositConfig,
+            get_auction_manager, AuctionManager, Key, PayoutTicket,
             SafetyDepositConfigV2, Store, MAX_PAYOUT_TICKET_SIZE, PREFIX, TOTALS,
         },
         utils::{

--- a/rust/metaplex/program/src/processor/empty_payment_account.rs
+++ b/rust/metaplex/program/src/processor/empty_payment_account.rs
@@ -5,8 +5,8 @@ use {
         error::MetaplexError,
         instruction::EmptyPaymentAccountArgs,
         state::{
-            get_auction_manager, AuctionManager, Key, PayoutTicket, Store, MAX_PAYOUT_TICKET_SIZE,
-            PREFIX, TOTALS,
+            get_auction_manager, AuctionManager, Key, PayoutTicket, SafetyDepositConfig,
+            SafetyDepositConfigV2, Store, MAX_PAYOUT_TICKET_SIZE, PREFIX, TOTALS,
         },
         utils::{
             assert_derivation, assert_initialized, assert_is_ata, assert_owned_by,
@@ -85,11 +85,23 @@ fn calculate_owed_amount(
     winning_config_item_index: &Option<u8>,
     creator_index: &Option<u8>,
 ) -> Result<u64, ProgramError> {
-    let primary_sale_happened = auction_manager.get_primary_sale_happened(
-        metadata,
-        *winning_config_index,
-        *winning_config_item_index,
-    )?;
+    msg!(
+        "safety_deposit_config_info: {:?}",
+        safety_deposit_config_info
+    );
+
+    let primary_sale_happened = match safety_deposit_config_info.and_then(|a| {
+        SafetyDepositConfigV2::from_account_info(a)
+            .map_err(|e| msg!("Error deserializing safety deposit config: {:?}", e))
+            .ok()
+    }) {
+        Some(safety_deposit_config) => safety_deposit_config.primary_sale_happened,
+        None => auction_manager.get_primary_sale_happened(
+            metadata,
+            *winning_config_index,
+            *winning_config_item_index,
+        )?,
+    };
 
     let mut amount_available_to_split: u128 = match winning_config_index {
         Some(index) => auction.bid_state.amount(*index as usize) as u128,

--- a/rust/metaplex/program/src/processor/validate_safety_deposit_box_v3.rs
+++ b/rust/metaplex/program/src/processor/validate_safety_deposit_box_v3.rs
@@ -1,0 +1,541 @@
+use {
+    crate::{
+        error::MetaplexError,
+        state::{
+            AuctionManager, AuctionManagerStatus, AuctionManagerV2, AuctionWinnerTokenTypeTracker,
+            Key, OriginalAuthorityLookup, SafetyDepositConfigV2, Store, WinningConfigType,
+            MAX_AUTHORITY_LOOKUP_SIZE, PREFIX, TOTALS,
+        },
+        utils::{
+            assert_at_least_one_creator_matches_or_store_public_and_all_verified,
+            assert_authority_correct, assert_derivation, assert_initialized, assert_owned_by,
+            assert_store_safety_vault_manager_match, create_or_allocate_account_raw,
+            transfer_metadata_ownership,
+        },
+    },
+    borsh::BorshSerialize,
+    metaplex_token_metadata::{
+        state::{MasterEditionV1, MasterEditionV2, Metadata},
+        utils::assert_update_authority_is_correct,
+    },
+    metaplex_token_vault::state::{SafetyDepositBox, Vault},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+    },
+    spl_token::state::{Account, Mint},
+};
+pub fn make_safety_deposit_config<'a>(
+    program_id: &Pubkey,
+    auction_manager_info: &AccountInfo<'a>,
+    safety_deposit_info: &AccountInfo<'a>,
+    safety_deposit_config_info: &AccountInfo<'a>,
+    payer_info: &AccountInfo<'a>,
+    rent_info: &AccountInfo<'a>,
+    system_info: &AccountInfo<'a>,
+    safety_deposit_config: &SafetyDepositConfigV2,
+    primary_sale_happened_from_metadata: bool,
+) -> ProgramResult {
+    let bump = assert_derivation(
+        program_id,
+        safety_deposit_config_info,
+        &[
+            PREFIX.as_bytes(),
+            program_id.as_ref(),
+            auction_manager_info.key.as_ref(),
+            safety_deposit_info.key.as_ref(),
+        ],
+    )?;
+
+    create_or_allocate_account_raw(
+        *program_id,
+        safety_deposit_config_info,
+        rent_info,
+        system_info,
+        payer_info,
+        safety_deposit_config.created_size(),
+        &[
+            PREFIX.as_bytes(),
+            program_id.as_ref(),
+            auction_manager_info.key.as_ref(),
+            safety_deposit_info.key.as_ref(),
+            &[bump],
+        ],
+    )?;
+
+    safety_deposit_config.create(
+        safety_deposit_config_info,
+        auction_manager_info.key,
+        primary_sale_happened_from_metadata,
+    )?;
+
+    Ok(())
+}
+
+pub struct CommonCheckArgs<'a, 'b> {
+    pub program_id: &'a Pubkey,
+    pub auction_manager_info: &'a AccountInfo<'a>,
+    pub metadata_info: &'a AccountInfo<'a>,
+    pub original_authority_lookup_info: &'a AccountInfo<'a>,
+    pub whitelisted_creator_info: &'a AccountInfo<'a>,
+    pub safety_deposit_info: &'a AccountInfo<'a>,
+    pub safety_deposit_token_store_info: &'a AccountInfo<'a>,
+    pub edition_info: &'a AccountInfo<'a>,
+    pub vault_info: &'a AccountInfo<'a>,
+    pub mint_info: &'a AccountInfo<'a>,
+    pub token_metadata_program_info: &'a AccountInfo<'a>,
+    pub auction_manager_store_info: &'a AccountInfo<'a>,
+    pub authority_info: &'a AccountInfo<'a>,
+    pub store: &'b Store,
+    pub auction_manager: &'b dyn AuctionManager,
+    pub metadata: &'b Metadata,
+    pub safety_deposit: &'b SafetyDepositBox,
+    pub vault: &'b Vault,
+    pub winning_config_type: &'b WinningConfigType,
+}
+
+pub fn assert_common_checks(args: CommonCheckArgs) -> ProgramResult {
+    let CommonCheckArgs {
+        program_id,
+        auction_manager_info,
+        metadata_info,
+        original_authority_lookup_info,
+        whitelisted_creator_info,
+        safety_deposit_info,
+        safety_deposit_token_store_info,
+        edition_info,
+        vault_info,
+        mint_info,
+        token_metadata_program_info,
+        auction_manager_store_info,
+        authority_info,
+        store,
+        auction_manager,
+        metadata,
+        safety_deposit,
+        vault,
+        winning_config_type,
+    } = args;
+
+    // Is it a real mint?
+    let _mint: Mint = assert_initialized(mint_info)?;
+
+    if vault.authority != *auction_manager_info.key {
+        return Err(MetaplexError::VaultAuthorityMismatch.into());
+    }
+
+    assert_owned_by(auction_manager_info, program_id)?;
+    assert_owned_by(metadata_info, &store.token_metadata_program)?;
+    if !original_authority_lookup_info.data_is_empty() {
+        return Err(MetaplexError::AlreadyInitialized.into());
+    }
+
+    if *whitelisted_creator_info.key != solana_program::system_program::id() {
+        if whitelisted_creator_info.data_is_empty() {
+            return Err(MetaplexError::Uninitialized.into());
+        }
+        assert_owned_by(whitelisted_creator_info, program_id)?;
+    }
+
+    assert_owned_by(auction_manager_store_info, program_id)?;
+    assert_owned_by(safety_deposit_info, &store.token_vault_program)?;
+    assert_owned_by(safety_deposit_token_store_info, &store.token_program)?;
+    assert_owned_by(mint_info, &store.token_program)?;
+
+    if *winning_config_type != WinningConfigType::TokenOnlyTransfer {
+        assert_owned_by(edition_info, &store.token_metadata_program)?;
+    }
+    assert_owned_by(vault_info, &store.token_vault_program)?;
+
+    if *token_metadata_program_info.key != store.token_metadata_program {
+        return Err(MetaplexError::AuctionManagerTokenMetadataMismatch.into());
+    }
+
+    assert_authority_correct(&auction_manager.authority(), authority_info)?;
+    assert_store_safety_vault_manager_match(
+        &auction_manager.vault(),
+        &safety_deposit_info,
+        vault_info,
+        &store.token_vault_program,
+    )?;
+    assert_at_least_one_creator_matches_or_store_public_and_all_verified(
+        program_id,
+        auction_manager,
+        &metadata,
+        whitelisted_creator_info,
+        auction_manager_store_info,
+    )?;
+
+    if auction_manager.store() != *auction_manager_store_info.key {
+        return Err(MetaplexError::AuctionManagerStoreMismatch.into());
+    }
+
+    if *mint_info.key != safety_deposit.token_mint {
+        return Err(MetaplexError::SafetyDepositBoxMintMismatch.into());
+    }
+
+    if *token_metadata_program_info.key != store.token_metadata_program {
+        return Err(MetaplexError::AuctionManagerTokenMetadataProgramMismatch.into());
+    }
+
+    // We want to ensure that the mint you are using with this token is one
+    // we can actually transfer to and from using our token program invocations, which
+    // we can check by asserting ownership by the token program we recorded in init.
+    if *mint_info.owner != store.token_program {
+        return Err(MetaplexError::TokenProgramMismatch.into());
+    }
+
+    Ok(())
+}
+
+pub struct SupplyLogicCheckArgs<'a, 'b> {
+    pub program_id: &'a Pubkey,
+    pub auction_manager_info: &'a AccountInfo<'a>,
+    pub metadata_info: &'a AccountInfo<'a>,
+    pub edition_info: &'a AccountInfo<'a>,
+    pub metadata_authority_info: &'a AccountInfo<'a>,
+    pub original_authority_lookup_info: &'a AccountInfo<'a>,
+    pub rent_info: &'a AccountInfo<'a>,
+    pub system_info: &'a AccountInfo<'a>,
+    pub payer_info: &'a AccountInfo<'a>,
+    pub token_metadata_program_info: &'a AccountInfo<'a>,
+    pub safety_deposit_token_store_info: &'a AccountInfo<'a>,
+    pub auction_manager: &'b dyn AuctionManager,
+    pub winning_config_type: &'b WinningConfigType,
+    pub metadata: &'b Metadata,
+    pub safety_deposit: &'b SafetyDepositBox,
+    pub store: &'b Store,
+    pub total_amount_requested: u64,
+}
+
+pub fn assert_supply_logic_check(args: SupplyLogicCheckArgs) -> ProgramResult {
+    let SupplyLogicCheckArgs {
+        program_id,
+        auction_manager_info,
+        metadata_info,
+        edition_info,
+        metadata_authority_info,
+        original_authority_lookup_info,
+        rent_info,
+        system_info,
+        payer_info,
+        token_metadata_program_info,
+        auction_manager,
+        winning_config_type,
+        metadata,
+        safety_deposit,
+        store,
+        safety_deposit_token_store_info,
+        total_amount_requested,
+    } = args;
+
+    let safety_deposit_token_store: Account = assert_initialized(safety_deposit_token_store_info)?;
+
+    let edition_seeds = &[
+        metaplex_token_metadata::state::PREFIX.as_bytes(),
+        store.token_metadata_program.as_ref(),
+        &metadata.mint.as_ref(),
+        metaplex_token_metadata::state::EDITION.as_bytes(),
+    ];
+
+    let (edition_key, _) =
+        Pubkey::find_program_address(edition_seeds, &store.token_metadata_program);
+
+    let auction_key = auction_manager.auction();
+    let seeds = &[PREFIX.as_bytes(), auction_key.as_ref()];
+    let (_, bump_seed) = Pubkey::find_program_address(seeds, &program_id);
+    let authority_seeds = &[PREFIX.as_bytes(), auction_key.as_ref(), &[bump_seed]];
+    // Supply logic check
+    match winning_config_type {
+        WinningConfigType::FullRightsTransfer => {
+            assert_update_authority_is_correct(&metadata, metadata_authority_info)?;
+
+            if safety_deposit.token_mint != metadata.mint {
+                return Err(MetaplexError::SafetyDepositBoxMetadataMismatch.into());
+            }
+            if edition_key != *edition_info.key {
+                return Err(MetaplexError::InvalidEditionAddress.into());
+            }
+
+            if safety_deposit_token_store.amount != 1 {
+                return Err(MetaplexError::StoreIsEmpty.into());
+            }
+
+            if total_amount_requested != 1 {
+                return Err(MetaplexError::NotEnoughTokensToSupplyWinners.into());
+            }
+
+            let auction_key = auction_manager.auction();
+
+            let original_authority_lookup_seeds = &[
+                PREFIX.as_bytes(),
+                auction_key.as_ref(),
+                metadata_info.key.as_ref(),
+            ];
+
+            let (expected_key, original_bump_seed) =
+                Pubkey::find_program_address(original_authority_lookup_seeds, &program_id);
+            let original_authority_seeds = &[
+                PREFIX.as_bytes(),
+                auction_key.as_ref(),
+                metadata_info.key.as_ref(),
+                &[original_bump_seed],
+            ];
+
+            if expected_key != *original_authority_lookup_info.key {
+                return Err(MetaplexError::OriginalAuthorityLookupKeyMismatch.into());
+            }
+
+            // We may need to transfer authority back, or to the new owner, so we need to keep track
+            // of original ownership
+            create_or_allocate_account_raw(
+                *program_id,
+                original_authority_lookup_info,
+                rent_info,
+                system_info,
+                payer_info,
+                MAX_AUTHORITY_LOOKUP_SIZE,
+                original_authority_seeds,
+            )?;
+
+            let mut original_authority_lookup =
+                OriginalAuthorityLookup::from_account_info(original_authority_lookup_info)?;
+            original_authority_lookup.key = Key::OriginalAuthorityLookupV1;
+
+            original_authority_lookup.original_authority = *metadata_authority_info.key;
+
+            transfer_metadata_ownership(
+                token_metadata_program_info.clone(),
+                metadata_info.clone(),
+                metadata_authority_info.clone(),
+                auction_manager_info.clone(),
+                authority_seeds,
+            )?;
+
+            original_authority_lookup
+                .serialize(&mut *original_authority_lookup_info.data.borrow_mut())?;
+        }
+        WinningConfigType::TokenOnlyTransfer => {
+            if safety_deposit.token_mint != metadata.mint {
+                return Err(MetaplexError::SafetyDepositBoxMetadataMismatch.into());
+            }
+            if safety_deposit_token_store.amount < total_amount_requested {
+                return Err(MetaplexError::NotEnoughTokensToSupplyWinners.into());
+            }
+        }
+        WinningConfigType::PrintingV1 => {
+            if edition_key != *edition_info.key {
+                return Err(MetaplexError::InvalidEditionAddress.into());
+            }
+            let master_edition = MasterEditionV1::from_account_info(edition_info)?;
+            if safety_deposit.token_mint != master_edition.printing_mint {
+                return Err(MetaplexError::SafetyDepositBoxMasterMintMismatch.into());
+            }
+
+            if safety_deposit_token_store.amount != total_amount_requested {
+                return Err(MetaplexError::NotEnoughTokensToSupplyWinners.into());
+            }
+        }
+        WinningConfigType::PrintingV2 => {
+            if edition_key != *edition_info.key {
+                return Err(MetaplexError::InvalidEditionAddress.into());
+            }
+            let master_edition = MasterEditionV2::from_account_info(edition_info)?;
+            if safety_deposit.token_mint != metadata.mint {
+                return Err(MetaplexError::SafetyDepositBoxMetadataMismatch.into());
+            }
+
+            if safety_deposit_token_store.amount != 1 {
+                return Err(MetaplexError::NotEnoughTokensToSupplyWinners.into());
+            }
+
+            if let Some(max) = master_edition.max_supply {
+                let amount_available = max
+                    .checked_sub(master_edition.supply)
+                    .ok_or(MetaplexError::NumericalOverflowError)?;
+                if amount_available < total_amount_requested {
+                    return Err(MetaplexError::NotEnoughTokensToSupplyWinners.into());
+                }
+            }
+        }
+        WinningConfigType::Participation => {
+            // Impossible to use a MEV1 through this avenue of participation...no one time auth token allowed here...
+            // If you wish to use those, you must use the AuctionManagerV1 pathway which allows use of the older endpoints,
+            // which will classify Participation as a PrintingV2 if it's an MEv2 or use the validate_participation endpoint
+            // if it's an MEv1.
+            if edition_key != *edition_info.key {
+                return Err(MetaplexError::InvalidEditionAddress.into());
+            }
+            let master_edition = MasterEditionV2::from_account_info(edition_info)?;
+            if safety_deposit.token_mint != metadata.mint {
+                return Err(MetaplexError::SafetyDepositBoxMetadataMismatch.into());
+            }
+
+            if safety_deposit_token_store.amount != 1 {
+                return Err(MetaplexError::NotEnoughTokensToSupplyWinners.into());
+            }
+
+            if master_edition.max_supply.is_some() {
+                return Err(
+                    MetaplexError::CantUseLimitedSupplyEditionsWithOpenEditionAuction.into(),
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn process_validate_safety_deposit_box_v3<'a>(
+    program_id: &'a Pubkey,
+    accounts: &'a [AccountInfo<'a>],
+    safety_deposit_config: SafetyDepositConfigV2,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let safety_deposit_config_info = next_account_info(account_info_iter)?;
+    let auction_token_tracker_info = next_account_info(account_info_iter)?;
+    let mut auction_manager_info = next_account_info(account_info_iter)?;
+    let metadata_info = next_account_info(account_info_iter)?;
+    let original_authority_lookup_info = next_account_info(account_info_iter)?;
+    let whitelisted_creator_info = next_account_info(account_info_iter)?;
+    let auction_manager_store_info = next_account_info(account_info_iter)?;
+    let safety_deposit_info = next_account_info(account_info_iter)?;
+    let safety_deposit_token_store_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let edition_info = next_account_info(account_info_iter)?;
+    let vault_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+    let metadata_authority_info = next_account_info(account_info_iter)?;
+    let payer_info = next_account_info(account_info_iter)?;
+    let token_metadata_program_info = next_account_info(account_info_iter)?;
+    let system_info = next_account_info(account_info_iter)?;
+    let rent_info = next_account_info(account_info_iter)?;
+
+    if !safety_deposit_config_info.data_is_empty() {
+        return Err(MetaplexError::AlreadyValidated.into());
+    }
+
+    assert_derivation(
+        program_id,
+        auction_token_tracker_info,
+        &[
+            PREFIX.as_bytes(),
+            &program_id.as_ref(),
+            auction_manager_info.key.as_ref(),
+            TOTALS.as_bytes(),
+        ],
+    )?;
+
+    let mut auction_manager = AuctionManagerV2::from_account_info(auction_manager_info)?;
+    let mut auction_token_tracker: AuctionWinnerTokenTypeTracker =
+        AuctionWinnerTokenTypeTracker::from_account_info(auction_token_tracker_info)?;
+    let safety_deposit = SafetyDepositBox::from_account_info(safety_deposit_info)?;
+    let metadata = Metadata::from_account_info(metadata_info)?;
+    let store = Store::from_account_info(auction_manager_store_info)?;
+    // Is it a real vault?
+    let vault = Vault::from_account_info(vault_info)?;
+
+    assert_common_checks(CommonCheckArgs {
+        program_id,
+        auction_manager_info,
+        metadata_info,
+        original_authority_lookup_info,
+        whitelisted_creator_info,
+        safety_deposit_info,
+        safety_deposit_token_store_info,
+        edition_info,
+        vault_info,
+        mint_info,
+        token_metadata_program_info,
+        auction_manager_store_info,
+        authority_info,
+        store: &store,
+        auction_manager: &auction_manager,
+        metadata: &metadata,
+        safety_deposit: &safety_deposit,
+        vault: &vault,
+        winning_config_type: &safety_deposit_config.winning_config_type,
+    })?;
+
+    let total_amount_requested = safety_deposit_config
+        .amount_ranges
+        .iter()
+        .map(|t| t.0 * t.1)
+        .sum();
+
+    assert_supply_logic_check(SupplyLogicCheckArgs {
+        program_id,
+        auction_manager_info,
+        metadata_info,
+        edition_info,
+        metadata_authority_info,
+        original_authority_lookup_info,
+        rent_info,
+        system_info,
+        payer_info,
+        token_metadata_program_info,
+        auction_manager: &auction_manager,
+        winning_config_type: &safety_deposit_config.winning_config_type,
+        metadata: &metadata,
+        safety_deposit: &safety_deposit,
+        store: &store,
+        safety_deposit_token_store_info,
+        total_amount_requested,
+    })?;
+
+    if safety_deposit_config.order != safety_deposit.order as u64 {
+        return Err(MetaplexError::SafetyDepositConfigOrderMismatch.into());
+    }
+
+    if safety_deposit_config.winning_config_type == WinningConfigType::PrintingV1 {
+        return Err(MetaplexError::PrintingV1NotAllowedWithAuctionManagerV2.into());
+    }
+
+    if safety_deposit_config.winning_config_type != WinningConfigType::Participation
+        && (safety_deposit_config.participation_config.is_some()
+            || safety_deposit_config.participation_state.is_some())
+    {
+        return Err(MetaplexError::InvalidOperation.into());
+    }
+
+    if safety_deposit_config.winning_config_type == WinningConfigType::Participation {
+        if auction_manager.state.has_participation {
+            return Err(MetaplexError::AlreadyHasOneParticipationPrize.into());
+        } else {
+            auction_manager.state.has_participation = true;
+        }
+    }
+
+    auction_manager.state.safety_config_items_validated = auction_manager
+        .state
+        .safety_config_items_validated
+        .checked_add(1)
+        .ok_or(MetaplexError::NumericalOverflowError)?;
+
+    if auction_manager.state.safety_config_items_validated == vault.token_type_count as u64 {
+        auction_manager.state.status = AuctionManagerStatus::Validated
+    }
+
+    auction_manager.save(&mut auction_manager_info)?;
+
+    if safety_deposit_config.winning_config_type != WinningConfigType::Participation {
+        auction_token_tracker.add_one_where_positive_ranges_occur(
+            &mut safety_deposit_config.amount_ranges.clone(),
+        )?;
+        auction_token_tracker.save(auction_token_tracker_info);
+    }
+
+    make_safety_deposit_config(
+        program_id,
+        auction_manager_info,
+        safety_deposit_info,
+        safety_deposit_config_info,
+        payer_info,
+        rent_info,
+        system_info,
+        &safety_deposit_config,
+        metadata.primary_sale_happened,
+    )?;
+    Ok(())
+}

--- a/rust/metaplex/program/src/state.rs
+++ b/rust/metaplex/program/src/state.rs
@@ -1552,7 +1552,7 @@ impl SafetyDepositConfigV2 {
     ) -> ProgramResult {
         let mut data = a.data.borrow_mut();
 
-        data[0] = Key::SafetyDepositConfigV1 as u8;
+        data[0] = Key::SafetyDepositConfigV2 as u8;
         // for whatever reason, copy_from_slice doesnt do jack here.
         let as_bytes = auction_manager_key.as_ref();
         for n in 0..32 {

--- a/rust/metaplex/program/src/state.rs
+++ b/rust/metaplex/program/src/state.rs
@@ -70,6 +70,22 @@ pub const BASE_SAFETY_CONFIG_SIZE: usize = 1 +// Key
  8 + // collected to accept payment
  20; // padding
 
+pub const BASE_SAFETY_CONFIG_SIZE_V2: usize = 1 +// Key
+ 32 + // auction manager lookup
+ 8 + // order
+ 1 + // winning config type
+ 1 + // amount tuple type
+ 1 + // length tuple type
+ 4 + // u32 for amount range vec
+ 1 + // participation config option
+ 1 + // winning constraint
+ 1 + // non winning constraint
+ 9 + // fixed price + option of it
+ 1 + // participation state option
+ 8 + // collected to accept payment
+ 1 + // is primary sale
+ 19; // padding
+
 #[repr(C)]
 #[derive(Clone, BorshSerialize, BorshDeserialize, PartialEq, Debug, Copy)]
 pub enum Key {
@@ -88,6 +104,7 @@ pub enum Key {
     AuctionWinnerTokenTypeTrackerV1,
     StoreIndexerV1,
     AuctionCacheV1,
+    SafetyDepositConfigV2,
 }
 
 pub struct CommonWinningIndexChecks<'a> {
@@ -507,6 +524,7 @@ impl AuctionManager for AuctionManagerV2 {
     ) -> Result<bool, ProgramError> {
         // Since auction v2s only support mev2s, and mev2s are always inside
         // the auction all the time, this is a valid thing to do.
+        msg!("calling get_primary_sale_happened");
         Ok(metadata.primary_sale_happened)
     }
 
@@ -821,6 +839,30 @@ pub struct SafetyDepositConfig {
     pub participation_state: Option<ParticipationStateV2>,
 }
 
+// Even though we dont use borsh for serialization to the chain, we do use this as an instruction argument
+// and that needs borsh.
+#[repr(C)]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+pub struct SafetyDepositConfigV2 {
+    pub key: Key,
+    /// reverse lookup
+    pub auction_manager: Pubkey,
+    // only 255 safety deposits on vault right now but soon this will likely expand.
+    /// safety deposit order
+    pub order: u64,
+    pub winning_config_type: WinningConfigType,
+    pub amount_type: TupleNumericType,
+    pub length_type: TupleNumericType,
+    /// Tuple is (amount of editions or tokens given to people in this range, length of range)
+    pub amount_ranges: Vec<AmountRange>,
+    /// if winning config type is "Participation" then you use this to parameterize it.
+    pub participation_config: Option<ParticipationConfigV2>,
+    /// if winning config type is "Participation" then you use this to keep track of it.
+    pub participation_state: Option<ParticipationStateV2>,
+    /// Mirrors primary_sale_happened on the MetaData by the time of listing.
+    pub primary_sale_happened: bool,
+}
+
 pub struct AmountCumulativeReturn {
     pub amount: u64,
     pub cumulative_amount: u64,
@@ -1106,13 +1148,13 @@ impl SafetyDepositConfig {
 
         let participation_state: Option<ParticipationStateV2> = match data[offset] {
             0 => {
-                // offset += 1;
+                offset += 1;
                 None
             }
             1 => {
                 let collected_to_accept_payment =
                     u64::from_le_bytes(*array_ref![data, offset + 1, 8]);
-                // offset += 9;
+                offset += 9;
                 Some(ParticipationStateV2 {
                     collected_to_accept_payment,
                 })
@@ -1120,8 +1162,7 @@ impl SafetyDepositConfig {
             _ => return Err(ProgramError::InvalidAccountData),
         };
 
-        // NOTE: Adding more fields? Uncomment the offset adjustments in participation state to keep
-        // the math working.
+        let _ = offset;
 
         Ok(SafetyDepositConfig {
             key: Key::SafetyDepositConfigV1,
@@ -1188,16 +1229,15 @@ impl SafetyDepositConfig {
                 data[offset] = 1;
                 *array_mut_ref![data, offset + 1, 8] =
                     val.collected_to_accept_payment.to_le_bytes();
-                //offset += 9;
+                offset += 9;
             }
             None => {
                 data[offset] = 0;
-                //offset += 1
+                offset += 1
             }
         }
 
-        // NOTE: Adding more fields? Uncomment the offset adjustments in participation state to keep
-        // the math working.
+        let _ = offset;
         Ok(())
     }
 
@@ -1236,6 +1276,383 @@ impl SafetyDepositConfig {
         // the math working.
     }
 }
+
+// TODO: CLEAN UP COPY-PASTA
+
+impl SafetyDepositConfigV2 {
+    /// Size of account with padding included
+    pub fn created_size(&self) -> usize {
+        return BASE_SAFETY_CONFIG_SIZE_V2
+            + (self.amount_type as usize + self.length_type as usize) * self.amount_ranges.len();
+    }
+
+    pub fn get_order(a: &AccountInfo) -> u64 {
+        let data = a.data.borrow();
+        return u64::from_le_bytes(*array_ref![data, ORDER_POSITION, 8]);
+    }
+
+    pub fn get_auction_manager(a: &AccountInfo) -> Pubkey {
+        let data = a.data.borrow();
+        return Pubkey::new_from_array(*array_ref![data, AUCTION_MANAGER_POSITION, 32]);
+    }
+
+    pub fn get_amount_type(a: &AccountInfo) -> Result<TupleNumericType, ProgramError> {
+        let data = &a.data.borrow();
+
+        Ok(match data[AMOUNT_POSITION] {
+            1 => TupleNumericType::U8,
+            2 => TupleNumericType::U16,
+            4 => TupleNumericType::U32,
+            8 => TupleNumericType::U64,
+            _ => return Err(ProgramError::InvalidAccountData),
+        })
+    }
+
+    pub fn get_length_type(a: &AccountInfo) -> Result<TupleNumericType, ProgramError> {
+        let data = &a.data.borrow();
+
+        Ok(match data[LENGTH_POSITION] {
+            1 => TupleNumericType::U8,
+            2 => TupleNumericType::U16,
+            4 => TupleNumericType::U32,
+            8 => TupleNumericType::U64,
+            _ => return Err(ProgramError::InvalidAccountData),
+        })
+    }
+
+    pub fn get_amount_range_len(a: &AccountInfo) -> u32 {
+        let data = &a.data.borrow();
+
+        return u32::from_le_bytes(*array_ref![data, AMOUNT_RANGE_SIZE_POSITION, 4]);
+    }
+
+    pub fn get_winning_config_type(a: &AccountInfo) -> Result<WinningConfigType, ProgramError> {
+        let data = &a.data.borrow();
+
+        Ok(match data[WINNING_CONFIG_POSITION] {
+            0 => WinningConfigType::TokenOnlyTransfer,
+            1 => WinningConfigType::FullRightsTransfer,
+            2 => WinningConfigType::PrintingV1,
+            3 => WinningConfigType::PrintingV2,
+            4 => WinningConfigType::Participation,
+            _ => return Err(ProgramError::InvalidAccountData),
+        })
+    }
+
+    /// Basically finds what edition offset you should get from 0 for your FIRST edition,
+    /// and the amount of editions you should get. If not a PrintingV2 safety deposit, the edition offset
+    /// (the cumulative count of all amounts from all people up to yours) is (relatively) meaningless,
+    /// but the amount AT your point still represents the amount of tokens you would receive.
+    /// Stop at winner index determines what the total roll count will stop at, if none goes all the way through.
+    pub fn find_amount_and_cumulative_offset(
+        a: &AccountInfo,
+        index: u64,
+        stop_at_winner_index: Option<usize>,
+    ) -> Result<AmountCumulativeReturn, ProgramError> {
+        let data = &mut a.data.borrow();
+
+        let amount_type = SafetyDepositConfigV2::get_amount_type(a)?;
+
+        let length_type = SafetyDepositConfigV2::get_length_type(a)?;
+
+        let length_of_array = SafetyDepositConfigV2::get_amount_range_len(a) as usize;
+
+        let mut cumulative_amount: u64 = 0;
+        let mut total_amount: u64 = 0;
+        let mut amount: u64 = 0;
+        let mut current_winner_range_start: u64 = 0;
+        let mut offset = AMOUNT_RANGE_FIRST_EL_POSITION;
+        let mut not_found = true;
+        for _ in 0..length_of_array {
+            let amount_each_winner_gets = get_number_from_data(data, amount_type, offset);
+
+            offset += amount_type as usize;
+
+            let length_of_range = get_number_from_data(data, length_type, offset);
+
+            offset += length_type as usize;
+
+            let current_winner_range_end = current_winner_range_start
+                .checked_add(length_of_range)
+                .ok_or(MetaplexError::NumericalOverflowError)?;
+            let to_add = amount_each_winner_gets
+                .checked_mul(length_of_range)
+                .ok_or(MetaplexError::NumericalOverflowError)?;
+
+            if index >= current_winner_range_start && index < current_winner_range_end {
+                let up_to_winner = (index - current_winner_range_start)
+                    .checked_mul(amount_each_winner_gets)
+                    .ok_or(MetaplexError::NumericalOverflowError)?;
+                cumulative_amount = cumulative_amount
+                    .checked_add(up_to_winner)
+                    .ok_or(MetaplexError::NumericalOverflowError)?;
+                amount = amount_each_winner_gets;
+
+                not_found = false;
+            } else if current_winner_range_start < index {
+                cumulative_amount = cumulative_amount
+                    .checked_add(to_add)
+                    .ok_or(MetaplexError::NumericalOverflowError)?;
+            }
+
+            if let Some(win_index) = stop_at_winner_index {
+                let win_index_as_u64 = win_index as u64;
+                if win_index_as_u64 >= current_winner_range_start
+                    && win_index_as_u64 < current_winner_range_end
+                {
+                    let up_to_winner = (win_index_as_u64 - current_winner_range_start)
+                        .checked_mul(amount_each_winner_gets)
+                        .ok_or(MetaplexError::NumericalOverflowError)?;
+                    total_amount = total_amount
+                        .checked_add(up_to_winner)
+                        .ok_or(MetaplexError::NumericalOverflowError)?;
+                    break;
+                } else if current_winner_range_start < win_index_as_u64 {
+                    total_amount = total_amount
+                        .checked_add(to_add)
+                        .ok_or(MetaplexError::NumericalOverflowError)?;
+                }
+            } else {
+                total_amount = total_amount
+                    .checked_add(to_add)
+                    .ok_or(MetaplexError::NumericalOverflowError)?;
+            }
+
+            current_winner_range_start = current_winner_range_end
+        }
+
+        if not_found {
+            return Err(MetaplexError::WinnerIndexNotFound.into());
+        }
+
+        Ok(AmountCumulativeReturn {
+            cumulative_amount,
+            total_amount,
+            amount,
+        })
+    }
+
+    pub fn from_account_info(a: &AccountInfo) -> Result<SafetyDepositConfigV2, ProgramError> {
+        let data = &mut a.data.borrow();
+        if a.data_len() < BASE_SAFETY_CONFIG_SIZE_V2 {
+            return Err(MetaplexError::DataTypeMismatch.into());
+        }
+
+        if data[0] != Key::SafetyDepositConfigV2 as u8 {
+            return Err(MetaplexError::DataTypeMismatch.into());
+        }
+
+        let auction_manager = SafetyDepositConfigV2::get_auction_manager(a);
+
+        let order = SafetyDepositConfigV2::get_order(a);
+
+        let winning_config_type = SafetyDepositConfigV2::get_winning_config_type(a)?;
+
+        let amount_type = SafetyDepositConfigV2::get_amount_type(a)?;
+
+        let length_type = SafetyDepositConfigV2::get_length_type(a)?;
+
+        let length_of_array = SafetyDepositConfigV2::get_amount_range_len(a);
+
+        let mut offset: usize = AMOUNT_RANGE_FIRST_EL_POSITION;
+        let mut amount_ranges = vec![];
+        for _ in 0..length_of_array {
+            let amount = get_number_from_data(data, amount_type, offset);
+
+            offset += amount_type as usize;
+
+            let length = get_number_from_data(data, length_type, offset);
+
+            amount_ranges.push(AmountRange(amount, length));
+            offset += length_type as usize;
+        }
+
+        let participation_config: Option<ParticipationConfigV2> = match data[offset] {
+            0 => {
+                offset += 1;
+                None
+            }
+            1 => {
+                let winner_constraint = match data[offset + 1] {
+                    0 => WinningConstraint::NoParticipationPrize,
+                    1 => WinningConstraint::ParticipationPrizeGiven,
+                    _ => return Err(ProgramError::InvalidAccountData),
+                };
+                let non_winning_constraint = match data[offset + 2] {
+                    0 => NonWinningConstraint::NoParticipationPrize,
+                    1 => NonWinningConstraint::GivenForFixedPrice,
+                    2 => NonWinningConstraint::GivenForBidPrice,
+                    _ => return Err(ProgramError::InvalidAccountData),
+                };
+
+                offset += 3;
+
+                let fixed_price: Option<u64> = match data[offset] {
+                    0 => {
+                        offset += 1;
+                        None
+                    }
+                    1 => {
+                        let number = u64::from_le_bytes(*array_ref![data, offset + 1, 8]);
+                        offset += 9;
+                        Some(number)
+                    }
+                    _ => return Err(ProgramError::InvalidAccountData),
+                };
+
+                Some(ParticipationConfigV2 {
+                    winner_constraint,
+                    non_winning_constraint,
+                    fixed_price,
+                })
+            }
+            _ => return Err(ProgramError::InvalidAccountData),
+        };
+
+        let participation_state: Option<ParticipationStateV2> = match data[offset] {
+            0 => {
+                offset += 1;
+                None
+            }
+            1 => {
+                let collected_to_accept_payment =
+                    u64::from_le_bytes(*array_ref![data, offset + 1, 8]);
+                offset += 9;
+                Some(ParticipationStateV2 {
+                    collected_to_accept_payment,
+                })
+            }
+            _ => return Err(ProgramError::InvalidAccountData),
+        };
+
+        let is_primary_sale: bool = data[offset] != 0;
+        offset += 1;
+
+        let _ = offset;
+
+        Ok(SafetyDepositConfigV2 {
+            key: Key::SafetyDepositConfigV2,
+            auction_manager,
+            order,
+            winning_config_type,
+            amount_type,
+            length_type,
+            amount_ranges,
+            participation_config,
+            participation_state,
+            primary_sale_happened: is_primary_sale,
+        })
+    }
+
+    pub fn create(
+        &self,
+        a: &AccountInfo,
+        auction_manager_key: &Pubkey,
+        primary_sale_happened_from_metadata: bool,
+    ) -> ProgramResult {
+        let mut data = a.data.borrow_mut();
+
+        data[0] = Key::SafetyDepositConfigV1 as u8;
+        // for whatever reason, copy_from_slice doesnt do jack here.
+        let as_bytes = auction_manager_key.as_ref();
+        for n in 0..32 {
+            data[n + 1] = as_bytes[n];
+        }
+        *array_mut_ref![data, ORDER_POSITION, 8] = self.order.to_le_bytes();
+        data[WINNING_CONFIG_POSITION] = self.winning_config_type as u8;
+        data[AMOUNT_POSITION] = self.amount_type as u8;
+        data[LENGTH_POSITION] = self.length_type as u8;
+        *array_mut_ref![data, AMOUNT_RANGE_SIZE_POSITION, 4] =
+            (self.amount_ranges.len() as u32).to_le_bytes();
+        let mut offset: usize = AMOUNT_RANGE_FIRST_EL_POSITION;
+        for range in &self.amount_ranges {
+            write_amount_type(&mut data, self.amount_type, offset, range);
+            offset += self.amount_type as usize;
+            write_length_type(&mut data, self.length_type, offset, range);
+            offset += self.length_type as usize;
+        }
+
+        match &self.participation_config {
+            Some(val) => {
+                data[offset] = 1;
+                data[offset + 1] = val.winner_constraint as u8;
+                data[offset + 2] = val.non_winning_constraint as u8;
+                offset += 3;
+                match val.fixed_price {
+                    Some(val) => {
+                        data[offset] = 1;
+                        *array_mut_ref![data, offset + 1, 8] = val.to_le_bytes();
+                        offset += 9;
+                    }
+                    None => {
+                        data[offset] = 0;
+                        offset += 1;
+                    }
+                }
+            }
+            None => {
+                data[offset] = 0;
+                offset += 1;
+            }
+        }
+
+        match &self.participation_state {
+            Some(val) => {
+                data[offset] = 1;
+                *array_mut_ref![data, offset + 1, 8] =
+                    val.collected_to_accept_payment.to_le_bytes();
+                offset += 9;
+            }
+            None => {
+                data[offset] = 0;
+                offset += 1
+            }
+        }
+
+        data[offset] = primary_sale_happened_from_metadata as u8;
+        offset += 1;
+
+        let _ = offset;
+        Ok(())
+    }
+
+    /// Smaller method for just participation state saving...saves cpu, and it's the only thing
+    /// that will ever change on this model.
+    pub fn save_participation_state(&mut self, a: &AccountInfo) {
+        let mut data = a.data.borrow_mut();
+        let mut offset: usize = AMOUNT_RANGE_FIRST_EL_POSITION
+            + self.amount_ranges.len() * (self.amount_type as usize + self.length_type as usize);
+
+        offset += match &self.participation_config {
+            Some(val) => {
+                let mut total = 4;
+                if val.fixed_price.is_some() {
+                    total += 8;
+                }
+                total
+            }
+            None => 1,
+        };
+
+        match &self.participation_state {
+            Some(val) => {
+                data[offset] = 1;
+                *array_mut_ref![data, offset + 1, 8] =
+                    val.collected_to_accept_payment.to_le_bytes();
+                //offset += 9;
+            }
+            None => {
+                data[offset] = 0;
+                //offset += 1
+            }
+        }
+
+        // NOTE: Adding more fields? Uncomment the offset adjustments in participation state to keep
+        // the math working.
+    }
+}
+
+// TODO: END OF CLEAN UP COPY-PASTA
 
 #[repr(C)]
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]

--- a/rust/metaplex/program/src/utils.rs
+++ b/rust/metaplex/program/src/utils.rs
@@ -494,7 +494,7 @@ pub fn assert_safety_deposit_config_valid(
                 ],
             )?;
 
-            if config.data.borrow()[0] != Key::SafetyDepositConfigV1 as u8 {
+            if config.data.borrow()[0] != Key::SafetyDepositConfigV1 as u8 && config.data.borrow()[0] != Key::SafetyDepositConfigV2 as u8 {
                 return Err(MetaplexError::DataTypeMismatch.into());
             }
         }


### PR DESCRIPTION
# Fix for auction primary sales distribution

The problem this solves is that pretty much on a multi-creator auction (let's use 3 as an example) where you have a 34, 33, 33 percent royalty distribution, the auction manager would close using the secondary sales percentage instead of the full 100%, giving the first seller a 93.4% of the funds and the rest a 3.4% or less approx. This occurs because the empty payment action looks at the metadata primary_sale_happened when deciding to do normal or secondary sale distribution. The primary sale flag is flipped when the user claims the item which often happens before funds are settled leading to secondary sale payout instead of primary.

## Steps to reproduce:

- 1. Create a multi creator NFT (34%, 33%, 33%).
- 2. Everyone signs it so you can list.
- 3. List it (Can be a 5m sale or an instant sale).
- 4. Buy with another account.
- 5. Get back to the original account and claim funds.
- 6. It will allocate funds in an unexpected way.

## Changes

Include an additional field on the safety deposit config snapshots the primary sale happened flag at the time of the listing creation. Then in empty payment evaluate the safe deposit config for is_primary_sale instead of the metadata since it was likely switched by the user redeeming the bid.