### PR TITLE
Bugfix/hola 152 listing with participation shows it and not nft

### DIFF
--- a/js/packages/common/src/contexts/meta/loadAccounts.ts
+++ b/js/packages/common/src/contexts/meta/loadAccounts.ts
@@ -293,23 +293,26 @@ export const loadAccounts = async (
     );
 
     const readyMetadata = auctionCaches.reduce((memo, auctionCache) => {
-      const setMetadata = auctionCache.info.metadata.map(async metadataKey => {
-        const metadata = state.metadataByMetadata[metadataKey];
+      const setMetadata = [auctionCache.info.metadata[0]].map(
+        async metadataKey => {
+          const metadata = state.metadataByMetadata[metadataKey];
 
-        let auctionMetadata =
-          state.metadataByAuction[auctionCache.info.auction];
+          let auctionMetadata =
+            state.metadataByAuction[auctionCache.info.auction];
 
-        auctionMetadata = auctionMetadata || ([] as ParsedAccount<Metadata>[]);
+          auctionMetadata =
+            auctionMetadata || ([] as ParsedAccount<Metadata>[]);
 
-        await metadata.info.init();
-        updateState('metadataByMint', metadata.info.mint, metadata);
-        updateState('metadata', '', metadata);
+          await metadata.info.init();
+          updateState('metadataByMint', metadata.info.mint, metadata);
+          updateState('metadata', '', metadata);
 
-        state.metadataByAuction[auctionCache.info.auction] = [
-          ...auctionMetadata,
-          metadata,
-        ];
-      });
+          state.metadataByAuction[auctionCache.info.auction] = [
+            ...auctionMetadata,
+            metadata,
+          ];
+        },
+      );
 
       return [...memo, ...setMetadata];
     }, [] as Promise<void>[]);

--- a/js/packages/common/src/contexts/meta/loadAccounts.ts
+++ b/js/packages/common/src/contexts/meta/loadAccounts.ts
@@ -293,26 +293,25 @@ export const loadAccounts = async (
     );
 
     const readyMetadata = auctionCaches.reduce((memo, auctionCache) => {
-      const setMetadata = [auctionCache.info.metadata[0]].map(
-        async metadataKey => {
-          const metadata = state.metadataByMetadata[metadataKey];
+      const setMetadata = auctionCache.info.metadata.map(async metadataKey => {
+        const metadata = state.metadataByMetadata[metadataKey];
 
-          let auctionMetadata =
-            state.metadataByAuction[auctionCache.info.auction];
+        let auctionMetadata =
+          state.metadataByAuction[auctionCache.info.auction];
 
-          auctionMetadata =
-            auctionMetadata || ([] as ParsedAccount<Metadata>[]);
+        auctionMetadata = auctionMetadata || ([] as ParsedAccount<Metadata>[]);
 
-          await metadata.info.init();
-          updateState('metadataByMint', metadata.info.mint, metadata);
-          updateState('metadata', '', metadata);
+        await metadata.info.init();
+        updateState('metadataByMint', metadata.info.mint, metadata);
+        updateState('metadata', '', metadata);
 
-          state.metadataByAuction[auctionCache.info.auction] = [
-            ...auctionMetadata,
-            metadata,
-          ];
-        },
-      );
+        const priorMetadata =
+          state.metadataByAuction[auctionCache.info.auction];
+
+        state.metadataByAuction[auctionCache.info.auction] = priorMetadata
+          ? [...priorMetadata, ...auctionMetadata, metadata]
+          : [...auctionMetadata, metadata];
+      });
 
       return [...memo, ...setMetadata];
     }, [] as Promise<void>[]);


### PR DESCRIPTION
@kespinola

OK, I finally figured out what was going on here.

Basically the map method used on line 295 of loadAccounts is mutating state on each iteration, and for auctions with a participation NFT, the participation NFT metadata was overwriting the main NFT metadata on the second iteration, which is why it wasn't being exposed at the view layer (and why either stopping at the first array item as in the prior commit, or using `.reverse()` before the map method also made it work).

I changed it so that if there are multiple iterations, the prior iterations are spread into the array first instead of being overwritten.

I did a lot of messing around on the view layer, and every other way of accomplishing this was really hacky and didn't jive with the auction cache correctly, so I really think we need to make this change here in loadAccounts.

Let me know if you have any other concerns or if this approach works.

Thanks!