### PR TITLE
Fix: Clear listing attributes when user selects diff listing type

### DIFF
--- a/js/packages/web/src/views/auctionCreate/categoryStep.tsx
+++ b/js/packages/web/src/views/auctionCreate/categoryStep.tsx
@@ -1,9 +1,12 @@
 import { Button, Col, Row, Space } from 'antd';
 import React from 'react';
-import { AuctionCategory } from '.';
+import { AuctionCategory, AuctionState } from '.';
 
 export const CategoryStep = (props: {
-  confirm: (category: AuctionCategory) => void;
+  confirm: () => void;
+  attributes: AuctionState;
+  freshAttributes: AuctionState;
+  setAttributes: (state: AuctionState) => void;
 }) => {
   return (
     <Space className="metaplex-fullwidth" direction="vertical">
@@ -43,7 +46,15 @@ export const CategoryStep = (props: {
                 className="metaplex-button-jumbo metaplex-fullwidth"
                 type="ghost"
                 size="large"
-                onClick={() => props.confirm(cat)}
+                onClick={() => {
+                  if (cat !== props.attributes.category) {
+                    props.setAttributes({
+                      ...props.freshAttributes,
+                      category: cat,
+                    });
+                  }
+                  props.confirm();
+                }}
               >
                 <div>{title}</div>
                 <div>{desc}</div>

--- a/js/packages/web/src/views/auctionCreate/index.tsx
+++ b/js/packages/web/src/views/auctionCreate/index.tsx
@@ -135,7 +135,7 @@ export const AuctionCreateView = () => {
   const mint = useMint(QUOTE_MINT);
   const { width } = useWindowDimensions();
   const [percentComplete, setPercentComplete] = useState(0);
-  const [rejection, setRejection] = useState<string>()
+  const [rejection, setRejection] = useState<string>();
   const [step, setStep] = useState<number>(1);
   const [stepsVisible, setStepsVisible] = useState<boolean>(true);
   const [auctionObj, setAuctionObj] = useState<
@@ -146,7 +146,8 @@ export const AuctionCreateView = () => {
       }
     | undefined
   >(undefined);
-  const [attributes, setAttributes] = useState<AuctionState>({
+
+  const freshAttributes: AuctionState = {
     reservationPrice: 0,
     items: [],
     category: AuctionCategory.Open,
@@ -155,7 +156,9 @@ export const AuctionCreateView = () => {
     winnersCount: 1,
     startSaleTS: undefined,
     startListTS: undefined,
-  });
+  };
+
+  const [attributes, setAttributes] = useState<AuctionState>(freshAttributes);
 
   const [tieredAttributes, setTieredAttributes] = useState<TieredAuctionState>({
     items: [],
@@ -176,8 +179,8 @@ export const AuctionCreateView = () => {
       },
       {
         programId: VAULT_ID,
-        processAccount: processVaultData
-      }
+        processAccount: processVaultData,
+      },
     );
   }, [connection]);
 
@@ -193,7 +196,9 @@ export const AuctionCreateView = () => {
 
   const createAuction = async () => {
     let winnerLimit: WinnerLimit;
-    let auctionInfo: { vault: string, auction: string, auctionManager: string } | undefined;
+    let auctionInfo:
+      | { vault: string; auction: string; auctionManager: string }
+      | undefined;
 
     if (
       attributes.category === AuctionCategory.InstantSale &&
@@ -500,7 +505,7 @@ export const AuctionCreateView = () => {
     const participationSafetyDepositDraft = isOpenEdition
       ? attributes.items[0]
       : attributes.participationNFT;
-    
+
     try {
       auctionInfo = await createAuctionManager(
         connection,
@@ -517,11 +522,10 @@ export const AuctionCreateView = () => {
     } catch (e: any) {
       setRejection(e.message);
       Bugsnag.notify(e);
-      return;  
+      return;
     }
 
     try {
-
       track('new_listing', {
         category: 'creation',
         label: isInstantSale ? 'instant sale' : 'auction',
@@ -540,10 +544,12 @@ export const AuctionCreateView = () => {
   const categoryStep = (
     <CategoryStep
       confirm={(category: AuctionCategory) => {
-        setAttributes({
-          ...attributes,
-          category,
-        });
+        if (category !== attributes.category) {
+          setAttributes({
+            ...freshAttributes,
+            category,
+          });
+        }
         gotoNextStep();
       }}
     />

--- a/js/packages/web/src/views/auctionCreate/index.tsx
+++ b/js/packages/web/src/views/auctionCreate/index.tsx
@@ -543,15 +543,10 @@ export const AuctionCreateView = () => {
 
   const categoryStep = (
     <CategoryStep
-      confirm={(category: AuctionCategory) => {
-        if (category !== attributes.category) {
-          setAttributes({
-            ...freshAttributes,
-            category,
-          });
-        }
-        gotoNextStep();
-      }}
+      confirm={() => gotoNextStep()}
+      attributes={attributes}
+      freshAttributes={freshAttributes}
+      setAttributes={setAttributes}
     />
   );
 


### PR DESCRIPTION
Fixes HOLA-119

Pretty simple, just added a const containing fresh listing state (lines 150 - 161) and then changed the listing type onclick to reset listing state to the fresh state if the user selects a different listing type than what they selected previously (lines 547 - 552)

The rest of the diff is just prettier formatting