### PR TITLE
maintain exact 5:1 banner ratio at all viewport widths

### DIFF
--- a/js/packages/web/src/components/Banner/index.tsx
+++ b/js/packages/web/src/components/Banner/index.tsx
@@ -23,7 +23,11 @@ export const Banner = ({
 
   return (
     <div id="metaplex-banner">
-      {src && <img id="metaplex-banner-backdrop" src={src} />}
+      {src && (
+        <div className="banner-wrapper">
+          <img id="metaplex-banner-backdrop" src={src} />
+        </div>
+      )}
 
       <div id="metaplex-banner-hero">
         <h1>{headingText}</h1>

--- a/js/packages/web/src/components/Banner/styles.less
+++ b/js/packages/web/src/components/Banner/styles.less
@@ -6,17 +6,31 @@
   position: relative;
 }
 
+.banner-wrapper {
+  --ratio-denom: 5;
+
+  width: 100%;
+  max-height: calc(
+    calc(100vw - calc(@content-padding * 2)) / var(--ratio-denom)
+  );
+  overflow: hidden;
+  border-radius: 8px;
+  margin-bottom: 30px;
+
+  // min-width media query set to: (max-content-width + (content-padding * 2))
+  @media screen and (min-width: 1504px) {
+    max-height: calc(@content-max-width / var(--ratio-denom));
+  }
+}
+
 #metaplex-banner-backdrop {
   left: 0;
   top: 0;
   right: 0;
   bottom: 0;
   width: 100%;
-  max-height: 258px;
   object-position: center;
   object-fit: cover;
-  margin-bottom: 30px;
-  border-radius: 8px;
 }
 
 #metaplex-banner-hero {


### PR DESCRIPTION
**old behavior:**  banner aspect ratio shifted with viewport width

**new behavior:**
- exact 5:1 ratio maintained at all viewport widths
    - unless image has a higher ratio, like 6:1, in which case that higher ratio is maintained
- if banner has lower ratio than 5:1 (e.g., 3:1), bottom of banner is cropped off to make a 5:1 ratio
- if image uploaded is smaller than the max-content-width (1440px wide), image size is increased to 1440px wide at the largest breakpoint

This seems like the most desired behavior to me, but please lmk if you have concerns