### PR TITLE
Make auction errors human-readable.

### DIFF
--- a/js/packages/common/src/contexts/connection.tsx
+++ b/js/packages/common/src/contexts/connection.tsx
@@ -8,6 +8,7 @@ import {
   Blockhash,
   clusterApiUrl,
   Commitment,
+  ConfirmOptions,
   Connection,
   FeeCalculator,
   Keypair,
@@ -15,9 +16,9 @@ import {
   SignatureStatus,
   SimulatedTransactionResponse,
   Transaction,
+  TransactionError,
   TransactionInstruction,
   TransactionSignature,
-  sendAndConfirmRawTransaction,
 } from '@solana/web3.js';
 import React, {
   ReactNode,
@@ -116,7 +117,7 @@ export function ConnectionProvider({
         .excludeByTag('nft')
         .filterByChainId(
           ENDPOINTS.find(end => end.endpoint === endpoint)?.ChainId ||
-          ChainId.MainnetBeta,
+            ChainId.MainnetBeta,
         )
         .getList();
 
@@ -287,7 +288,7 @@ export const sendTransactions = async (
   sequenceType: SequenceType = SequenceType.Parallel,
   commitment: Commitment = 'singleGossip',
   successCallback: (txid: string, ind: number) => void = () => { },
-  failCallback: (reason: string, ind: number) => boolean = () => false,
+  failCallback: (err: SendAndConfirmError, ind: number) => boolean = () => false,
   block?: BlockhashAndFeeCalculator,
 ): Promise<number> => {
   if (!wallet.publicKey) throw new WalletNotConnectedError();
@@ -324,7 +325,7 @@ export const sendTransactions = async (
 
   const signedTxns = await wallet.signAllTransactions(unsignedTxns);
 
-  const pendingTxns: Promise<{ txid: string; slot: number }>[] = [];
+  const pendingTxns: Promise<SendSignedTransactionResult>[] = [];
 
   const breakEarlyObject = { breakEarly: false, i: 0 };
   console.log(
@@ -340,12 +341,17 @@ export const sendTransactions = async (
     });
 
     signedTxnPromise
-      .then(({ txid }) => {
+      .then(res => {
+        if (res.err) {
+          failCallback(res.err, i);
+          throw new Error(`Instructions set ${i} failed: ${res.err.type}`);
+        }
+
+        const { txid } = res;
         console.log(`Instructions set ${i} succeeded. Transaction Id ${txid}`);
         successCallback(txid, i);
       })
-      .catch((e) => {
-        failCallback(e.message, i);
+      .catch(() => {
         console.log(`Instructions set ${i} failed.`);
         if (sequenceType === SequenceType.StopOnFailure) {
           breakEarlyObject.breakEarly = true;
@@ -368,7 +374,7 @@ export const sendTransactions = async (
     }
   }
 
-  if (sequenceType !== SequenceType.Parallel) {
+  if (pendingTxns.length) {
     await Promise.all(pendingTxns);
   }
 
@@ -464,7 +470,7 @@ export const sendTransactionWithRetry = async (
   includesFeePayer: boolean = false,
   block?: BlockhashAndFeeCalculator,
   beforeSend?: () => void,
-): Promise<{ txid: string, slot: number }> => {
+): Promise<SendSignedTransactionResult> => {
   if (!wallet.publicKey) throw new WalletNotConnectedError();
 
   let transaction = new Transaction();
@@ -494,12 +500,10 @@ export const sendTransactionWithRetry = async (
     beforeSend();
   }
 
-  const { txid, slot } = await sendSignedTransaction({
+  return await sendSignedTransaction({
     connection,
     signedTransaction: transaction,
   });
-
-  return { txid, slot };
 };
 
 export const getUnixTs = () => {
@@ -508,30 +512,77 @@ export const getUnixTs = () => {
 
 const DEFAULT_TIMEOUT = 30000;
 
+export type SendAndConfirmError =
+  | { type: 'tx-error'; inner: TransactionError; txid: TransactionSignature }
+  | { type: 'misc-error'; inner: unknown; txid?: TransactionSignature };
+
+/** Mirror of web3.js's `sendAndConfirmRawTransaction`, but with better errors. */
+export async function sendAndConfirmRawTransactionEx(
+  connection: Connection,
+  rawTransaction: Buffer,
+  options?: ConfirmOptions,
+): Promise<
+  | { ok: TransactionSignature; err?: undefined }
+  | { ok?: undefined; err: SendAndConfirmError }
+> {
+  let txid: string | undefined;
+
+  try {
+    const sendOptions = options && {
+      skipPreflight: options.skipPreflight,
+      preflightCommitment: options.preflightCommitment || options.commitment,
+    };
+
+    txid = await connection.sendRawTransaction(rawTransaction, sendOptions);
+
+    const status = (
+      await connection.confirmTransaction(txid, options && options.commitment)
+    ).value;
+
+    if (status.err) {
+      return { err: { type: 'tx-error', inner: status.err, txid } };
+    }
+
+    return { ok: txid };
+  } catch (e) {
+    return { err: { type: 'misc-error', inner: e, txid } };
+  }
+}
+
+export type SendSignedTransactionResult =
+  | { txid: string; slot: number; err?: undefined }
+  | { txid?: undefined; err: SendAndConfirmError };
+
 export async function sendSignedTransaction({
   signedTransaction,
   connection,
 }: {
   signedTransaction: Transaction;
   connection: Connection;
-  sendingMessage?: string;
-  sentMessage?: string;
-  successMessage?: string;
-  timeout?: number;
-}): Promise<{ txid: string; slot: number }> {
+  // sendingMessage?: string;
+  // sentMessage?: string;
+  // successMessage?: string;
+  // timeout?: number;
+}): Promise<SendSignedTransactionResult> {
   const rawTransaction = signedTransaction.serialize();
   let slot = 0;
 
-  const txid = await sendAndConfirmRawTransaction(
+  const result = await sendAndConfirmRawTransactionEx(
     connection,
     rawTransaction,
     {
       skipPreflight: true,
-      commitment: 'confirmed'
-    }
+      commitment: 'confirmed',
+    },
   );
 
-  const confirmation = await connection.getConfirmedTransaction(txid, 'confirmed');
+  if (result.err) return { err: result.err };
+
+  const { ok: txid } = result;
+  const confirmation = await connection.getConfirmedTransaction(
+    txid,
+    'confirmed',
+  );
 
   if (confirmation) {
     slot = confirmation.slot;

--- a/js/packages/web/src/actions/createAuctionManager.ts
+++ b/js/packages/web/src/actions/createAuctionManager.ts
@@ -107,7 +107,7 @@ export async function createAuctionManager(
   connection: Connection,
   wallet: WalletSigner,
   progressCallback: Dispatch<SetStateAction<number>>,
-  failureCallback: Dispatch<SetStateAction<SendAndConfirmError | undefined>>,
+  failureCallback: (err: SendAndConfirmError) => void,
   whitelistedCreatorsByCreator: Record<
     string,
     ParsedAccount<WhitelistedCreator>
@@ -369,7 +369,9 @@ export async function createAuctionManager(
 
   if (rejection) {
     failureCallback(rejection);
-    throw new Error(`Failed to create auction manager: ${rejection.type}`);
+    throw new Error(
+      `Failed to create auction manager: ${JSON.stringify(rejection)}`,
+    );
   }
 
   return { vault, auction, auctionManager };

--- a/js/packages/web/src/actions/sendPlaceBid.ts
+++ b/js/packages/web/src/actions/sendPlaceBid.ts
@@ -48,13 +48,17 @@ export async function sendPlaceBid(
     signers,
   );
 
-  const { txid } = await sendTransactionWithRetry(
+  const res = await sendTransactionWithRetry(
     connection,
     wallet,
     instructions[0],
     signers[0],
     commitment,
   );
+
+  if (res.err) throw res.err.inner;
+
+  const { txid } = res;
 
   return {
     amount: bid,

--- a/js/packages/web/src/actions/sendSignMetadata.ts
+++ b/js/packages/web/src/actions/sendSignMetadata.ts
@@ -1,5 +1,6 @@
 import { Keypair, Connection, TransactionInstruction } from '@solana/web3.js';
 import {
+  SendSignedTransactionResult,
   sendTransactionWithRetry,
   signMetadata,
   StringPublicKey,
@@ -11,7 +12,7 @@ export async function sendSignMetadata(
   connection: Connection,
   wallet: WalletSigner,
   metadata: StringPublicKey,
-): Promise<string> {
+): Promise<SendSignedTransactionResult> {
   if (!wallet.publicKey) throw new WalletNotConnectedError();
 
   const signers: Keypair[] = [];
@@ -19,13 +20,11 @@ export async function sendSignMetadata(
 
   await signMetadata(metadata, wallet.publicKey.toBase58(), instructions);
 
-  const { txid } = await sendTransactionWithRetry(
+  return await sendTransactionWithRetry(
     connection,
     wallet,
     instructions,
     signers,
     'confirmed',
   );
-
-  return txid;
 }

--- a/js/packages/web/src/components/ClickToCopy/index.tsx
+++ b/js/packages/web/src/components/ClickToCopy/index.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, {
+  useEffect,
+  useState,
+  ReactElement,
+  ReactNode,
+  useCallback,
+} from 'react';
 
 const CopyIcon = () => (
   <svg
@@ -44,7 +50,22 @@ const Checkmark = () => (
   </svg>
 );
 
-export const ClickToCopy = ({ copyText }: { copyText: string }) => {
+export const ClickToCopy = ({
+  copyText,
+  render,
+}: {
+  copyText: string;
+  render?: (icon: ReactNode, onClick: () => void) => ReactElement<any, any> | null;
+}) => {
+  const el = useCallback(
+    render ??
+      ((icon: ReactNode, click: () => void) => (
+        <div onClick={click} title="Click to copy pubkey">
+          {icon}
+        </div>
+      )),
+    [render],
+  );
   const [clicked, setClicked] = useState(false);
 
   useEffect(() => {
@@ -59,9 +80,5 @@ export const ClickToCopy = ({ copyText }: { copyText: string }) => {
     setClicked(true);
   };
 
-  return (
-    <div onClick={onClick} title="Click to copy pubkey">
-      {clicked ? <Checkmark /> : <CopyIcon />}
-    </div>
-  );
+  return el(clicked ? <Checkmark /> : <CopyIcon />, onClick);
 };

--- a/js/packages/web/src/views/art/index.tsx
+++ b/js/packages/web/src/views/art/index.tsx
@@ -171,8 +171,11 @@ export const ArtView = () => {
                               }
 
                               try {
-                                const txid = await sendSignMetadata(connection, wallet, nft);
+                                const res = await sendSignMetadata(connection, wallet, nft);
 
+                                if (res.err) throw res.err.inner;
+
+                                const { txid } = res;
                                 const tx = await connection.getTransaction(txid, {
                                   commitment: 'confirmed',
                                 });

--- a/js/packages/web/src/views/auctionCreate/index.tsx
+++ b/js/packages/web/src/views/auctionCreate/index.tsx
@@ -137,7 +137,7 @@ export const AuctionCreateView = () => {
   const mint = useMint(QUOTE_MINT);
   const { width } = useWindowDimensions();
   const [percentComplete, setPercentComplete] = useState(0);
-  let [rejection, setRejection] = useState<SendAndConfirmError | undefined>();
+  const [rejection, setRejection] = useState<SendAndConfirmError | undefined>();
   const [step, setStep] = useState<number>(1);
   const [stepsVisible, setStepsVisible] = useState<boolean>(true);
   const [auctionObj, setAuctionObj] = useState<
@@ -508,41 +508,21 @@ export const AuctionCreateView = () => {
       ? attributes.items[0]
       : attributes.participationNFT;
 
-    const txid = prompt('Txid?') ?? '';
-    const tx = await connection.getTransaction(txid, { commitment: 'confirmed' });
-
-    console.log({ txid, tx });
-
-    if (tx?.meta?.err) {
-      rejection = { type: 'tx-error', inner: tx.meta.err, txid };
-    } else {
-      rejection = {
-        type: 'misc-error',
-        inner: tx?.transaction.message ?? 'transaction had no error',
-      };
-    }
-
-    rejection = rejection ?? { type: 'misc-error', inner: 'frick' };
-    setRejection(rejection);
-
     try {
-      if (false as boolean) {
-        auctionInfo = await createAuctionManager(
-          connection,
-          wallet,
-          setPercentComplete,
-          setRejection,
-          whitelistedCreatorsByCreator,
-          auctionSettings,
-          safetyDepositDrafts,
-          participationSafetyDepositDraft,
-          QUOTE_MINT.toBase58(),
-          storeIndexer,
-        );
-      }
+      auctionInfo = await createAuctionManager(
+        connection,
+        wallet,
+        setPercentComplete,
+        setRejection,
+        whitelistedCreatorsByCreator,
+        auctionSettings,
+        safetyDepositDrafts,
+        participationSafetyDepositDraft,
+        QUOTE_MINT.toBase58(),
+        storeIndexer,
+      );
     } catch (e: any) {
       setRejection(r => r ?? { type: 'misc-error', inner: e });
-      Bugsnag.notify(e);
     }
 
     if (rejection) {

--- a/js/packages/web/src/views/auctionCreate/index.tsx
+++ b/js/packages/web/src/views/auctionCreate/index.tsx
@@ -509,7 +509,8 @@ export const AuctionCreateView = () => {
       : attributes.participationNFT;
 
     // Track useState updates across this callback for rejection
-    let tmpRejection = rejection;
+    let tmpRejection = undefined;
+    setRejection(undefined);
 
     try {
       auctionInfo = await createAuctionManager(
@@ -517,8 +518,8 @@ export const AuctionCreateView = () => {
         wallet,
         setPercentComplete,
         rej => {
-          setRejection(rej);
-          tmpRejection = rej;
+          setRejection(r => r ?? rej);
+          tmpRejection ??= rej;
         },
         whitelistedCreatorsByCreator,
         auctionSettings,

--- a/js/packages/web/src/views/auctionCreate/index.tsx
+++ b/js/packages/web/src/views/auctionCreate/index.tsx
@@ -508,12 +508,18 @@ export const AuctionCreateView = () => {
       ? attributes.items[0]
       : attributes.participationNFT;
 
+    // Track useState updates across this callback for rejection
+    let tmpRejection = rejection;
+
     try {
       auctionInfo = await createAuctionManager(
         connection,
         wallet,
         setPercentComplete,
-        setRejection,
+        rej => {
+          setRejection(rej);
+          tmpRejection = rej;
+        },
         whitelistedCreatorsByCreator,
         auctionSettings,
         safetyDepositDrafts,
@@ -522,10 +528,12 @@ export const AuctionCreateView = () => {
         storeIndexer,
       );
     } catch (e: any) {
-      setRejection(r => r ?? { type: 'misc-error', inner: e });
+      const rej: SendAndConfirmError = { type: 'misc-error', inner: e };
+      setRejection(r => r ?? rej);
+      tmpRejection ??= rej;
     }
 
-    if (rejection) {
+    if (tmpRejection) {
       Bugsnag.notify({
         name: 'createAuctionManager failure',
         message: JSON.stringify(rejection),

--- a/js/packages/web/src/views/auctionCreate/waitingStep.tsx
+++ b/js/packages/web/src/views/auctionCreate/waitingStep.tsx
@@ -1,13 +1,55 @@
-import { Card, Row, Col, Space, Progress, Typography } from 'antd';
-import React, { useEffect } from 'react';
+import { TransactionResponse } from '@solana/web3.js';
+import {
+  Button,
+  Card,
+  Row,
+  Col,
+  Divider,
+  Spin,
+  Space,
+  Progress,
+  Typography,
+} from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
+import React, { ReactNode, useEffect, useState } from 'react';
+import {
+  SendAndConfirmError,
+  useConnection,
+} from '../../../../common/dist/lib';
 
 const { Title } = Typography;
+
+const hasMessage = (e: object): e is { message: unknown } => 'message' in e;
+
+const isCustomInstructionErr = (
+  e: unknown,
+): e is { InstructionError: [number, { Custom: number }] } => {
+  if (!(typeof e === 'object' && e && 'InstructionError' in e)) return false;
+
+  const { InstructionError: err } = e as any;
+
+  if (!(err instanceof Array && err.length === 2)) return false;
+  const [id, ierr] = err;
+
+  return (
+    typeof id === 'number' &&
+    typeof ierr === 'object' &&
+    ierr &&
+    'Custom' in ierr &&
+    typeof ierr.Custom === 'number'
+  );
+};
 
 export const WaitingStep = (props: {
   createAuction: () => Promise<void>;
   percent: number;
-  rejection?: string;
+  rejection?: SendAndConfirmError | undefined;
 }) => {
+  const connection = useConnection();
+  const [rejectedTx, setRejectedTx] = useState<TransactionResponse | undefined>(
+    undefined,
+  );
+
   useEffect(() => {
     const func = async () => {
       await props.createAuction();
@@ -15,39 +57,168 @@ export const WaitingStep = (props: {
     func();
   }, []);
 
+  useEffect(() => {
+    setRejectedTx(undefined);
+
+    if (props.rejection?.txid) {
+      connection
+        .getTransaction(props.rejection.txid, { commitment: 'confirmed' })
+        .catch(e => console.error(e))
+        .then(t => setRejectedTx(t ?? undefined));
+    }
+  }, [props.rejection]);
 
   let title = 'Listing NFT with Metaplex...';
-  let description = 'This may take a minute or two depending current network demand.';
+  let description: ReactNode =
+    'This may take several minutes depending current network demand.';
   let status: 'normal' | 'exception' = 'normal';
 
   if (props.rejection) {
     title = 'Issue Listing with Metaplex!';
-    description = props.rejection;
     status = 'exception';
+
+    const { txid } = props.rejection;
+    let descriptionInner: ReactNode;
+
+    switch (props.rejection.type) {
+      case 'tx-error': {
+        const err = props.rejection.inner;
+
+        if (isCustomInstructionErr(err)) {
+          const {
+            InstructionError: [ins, { Custom: code }],
+          } = err;
+
+          if (rejectedTx) {
+            console.log(rejectedTx);
+          }
+
+          descriptionInner = (
+            <>
+              <p>
+                Instruction #{ins + 1} failed with code{' '}
+                <code>0x{code.toString(16)}</code>
+              </p>
+            </>
+          );
+        } else {
+          descriptionInner = (
+            <>
+              <p>An unexpected Solana error occurred:</p>
+              <pre>{JSON.stringify(err)}</pre>
+            </>
+          );
+        }
+
+        break;
+      }
+      case 'misc-error': {
+        const { inner } = props.rejection;
+
+        let msg: string;
+
+        if (typeof inner === 'object' && inner && hasMessage(inner)) {
+          const { message } = inner;
+          msg = typeof message === 'string' ? message : JSON.stringify(message);
+        } else {
+          msg = JSON.stringify(inner);
+        }
+
+        descriptionInner = (
+          <>
+            An unexpected error occurred:
+            <pre>{msg}</pre>
+          </>
+        );
+
+        break;
+      }
+    }
+
+    const solscanLink = txid && `https://solscan.io/tx/${txid}`;
+
+    description = (
+      <>
+        <h3>Transaction failed</h3>
+        {txid && (
+          <p>
+            Signature:{' '}
+            <code style={{ overflowWrap: 'break-word' }}>{txid}</code>
+          </p>
+        )}
+        {txid && !rejectedTx && (
+          <Row justify="center">
+            <Col flex="0 0 auto">
+              <Spin indicator={<LoadingOutlined />} />
+            </Col>
+          </Row>
+        )}
+        {descriptionInner}
+        {solscanLink && (
+          <>
+            <p>
+              Solscan link:
+              <br />
+              <a
+                href={solscanLink}
+                style={{
+                  textOverflow: 'ellipsis',
+                  maxWidth: '100%',
+                  display: 'inline-block',
+                  overflow: 'hidden',
+                }}
+              >
+                {solscanLink}
+              </a>
+              <br />
+              <Button
+                type="primary"
+                size="large"
+                onClick={() => {
+                  navigator.clipboard.writeText(solscanLink);
+                }}
+              >
+                Copy Solscan link
+              </Button>
+            </p>
+          </>
+        )}
+        {rejectedTx?.meta?.logMessages && (
+          <>
+            <p>Transaction log:</p>
+            {rejectedTx.meta.logMessages.map((m, i) => (
+              <div key={i}>
+                {i > 0 && <Divider />}
+                <code style={{ whiteSpace: 'pre-wrap' }}>{m}</code>
+              </div>
+            ))}
+          </>
+        )}
+      </>
+    );
   }
 
   return (
     <Row justify="center">
       <Col xs={22} md={16} lg={12}>
-        <Card
-        >
-            <Space direction="vertical" size="large" className="metaplex-fullwidth">
-          <Row justify="center">
-            <Progress
-              status={status}
-              type="circle"
-              width={140}
-              percent={props.percent}
+        <Card>
+          <Space
+            direction="vertical"
+            size="large"
+            className="metaplex-fullwidth"
+          >
+            <Row justify="center">
+              <Progress
+                status={status}
+                type="circle"
+                width={140}
+                percent={props.percent}
+              />
+            </Row>
+            <Card.Meta
+              title={<Title level={5}>{title}</Title>}
+              description={description}
             />
-          </Row>
-          <Card.Meta
-            title={
-              <Title level={5}>
-                {title}
-              </Title>
-            }
-            description={description}
-          />
           </Space>
         </Card>
       </Col>


### PR DESCRIPTION
I have not added a map from Metaplex errors to printable status info yet, but I have reconfigured how errors are passed around such that we should now be able to retrieve all the relevant information.

I also added a copyable Solscan link to the error page to make referring errors to #tech-support easier.