### PR TITLE
Revert removal of Open & Tiered listing creation?

### DIFF
--- a/js/packages/web/src/views/auctionCreate/categoryStep.tsx
+++ b/js/packages/web/src/views/auctionCreate/categoryStep.tsx
@@ -27,16 +27,16 @@ export const CategoryStep = (props: {
                 title: 'Limited Edition',
                 desc: 'Sell a limited copy or copies of a single Master NFT',
               },
-              // {
-              //   cat: AuctionCategory.Open,
-              //   title: 'Open Edition',
-              //   desc: 'Sell unlimited copies of a single Master NFT',
-              // },
-              // {
-              //   cat: AuctionCategory.Tiered,
-              //   title: 'Tiered Auction',
-              //   desc: 'Participants get unique rewards based on their leaderboard rank',
-              // },
+              {
+                cat: AuctionCategory.Open,
+                title: 'Open Edition',
+                desc: 'Sell unlimited copies of a single Master NFT',
+              },
+              {
+                cat: AuctionCategory.Tiered,
+                title: 'Tiered Auction',
+                desc: 'Participants get unique rewards based on their leaderboard rank',
+              },
             ].map(({ cat, title, desc }) => (
               <Button
                 key={cat}


### PR DESCRIPTION
[The options to create an open / tiered listings were removed in this commit. Was it a deliberate removal or was it just collateral damage in the refactor? 😆](https://github.com/holaplex/metaplex/commit/7c620482ea83db301596bb4e55ba4b2494e2eb03#diff-c586dd62d78617d926294093932843a22a96a84dbce4528c1ba016e562ffdd8a)

Regardless it is still possible to create "open" listings under the 'instant sale' category, but the UX for doing so is less than ideal. IMO it's too easy for someone to accidentally list the master instead of the prints/copies
![image](https://user-images.githubusercontent.com/90072984/146653610-a58e6170-a9c3-44ce-b535-411c3e4d9443.png)

Additionally (and this is the real show-stopper), the listings are incorrectly displayed as being sold out, likely because the frontend is trying to read `maxSupply` when it doesn't exist