### PR TITLE
Calculate Listing Cost

### DIFF
--- a/js/packages/web/src/utils/utils.ts
+++ b/js/packages/web/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { Connection, Transaction } from '@solana/web3.js';
+
 export const cleanName = (name?: string): string | undefined => {
   if (!name) {
     return undefined;
@@ -12,4 +14,21 @@ export const getLast = <T>(arr: T[]) => {
   }
 
   return arr[arr.length - 1];
+};
+
+export const calculateTransactionCost = async (
+  connection: Connection,
+  transaction: Transaction,
+) => {
+  const recentBlockhash = await connection.getRecentBlockhash();
+  const lamportsPerSignature =
+    recentBlockhash.feeCalculator.lamportsPerSignature; // Signature Cost
+  const signatureCount = 1; // Let's assume only 1 signature is needed
+  const initialCost = lamportsPerSignature * signatureCount;
+  const allCosts = await Promise.all(
+    transaction.instructions.map(instruction =>
+      connection.getMinimumBalanceForRentExemption(instruction.data.byteLength),
+    ),
+  );
+  return initialCost + allCosts.reduce((acc, curr) => acc + curr, 0);
 };

--- a/js/packages/web/src/views/auctionCreate/reviewStep.tsx
+++ b/js/packages/web/src/views/auctionCreate/reviewStep.tsx
@@ -1,9 +1,55 @@
-import { Connection } from '@solana/web3.js';
+import {
+  MAX_AUCTION_DATA_EXTENDED_SIZE,
+  MAX_EXTERNAL_ACCOUNT_SIZE,
+  MAX_VAULT_SIZE,
+} from '@oyster/common';
+import { Connection, LAMPORTS_PER_SOL } from '@solana/web3.js';
 import { Button, Col, Divider, Row, Space, Statistic } from 'antd';
 import moment from 'moment';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { AuctionCategory, AuctionState } from '.';
+import { AmountLabel } from '../../components/AmountLabel';
 import { ArtCard } from '../../components/ArtCard';
+
+// TODO: Move to common
+const BASE_SAFETY_CONFIG_SIZE =
+  1 + // Key
+  32 + // auction manager lookup
+  8 + // order
+  1 + // winning config type
+  1 + // amount tuple type
+  1 + // length tuple type
+  4 + // u32 for amount range vec
+  1 + // participation config option
+  1 + // winning constraint
+  1 + // non winning constraint
+  9 + // fixed price + option of it
+  1 + // participation state option
+  8 + // collected to accept payment
+  20; // padding
+
+const calculateAuctionCreationCost = async (connection: Connection) => {
+  const maxVaultSize =
+    connection.getMinimumBalanceForRentExemption(MAX_VAULT_SIZE);
+  const maxExternalAccountSize = connection.getMinimumBalanceForRentExemption(
+    MAX_EXTERNAL_ACCOUNT_SIZE,
+  );
+  const auctionCosts = connection.getMinimumBalanceForRentExemption(
+    MAX_AUCTION_DATA_EXTENDED_SIZE,
+  );
+  // SAFETY DEPOSIT BOX COSTS
+  const safetyDepositBoxCosts = connection.getMinimumBalanceForRentExemption(
+    BASE_SAFETY_CONFIG_SIZE,
+  );
+  // There are probably a few more costs to account for, but this is a good start
+  const allValues = await Promise.all([
+    maxVaultSize,
+    maxExternalAccountSize,
+    auctionCosts,
+    safetyDepositBoxCosts,
+  ]);
+  return allValues.reduce((acc, curr) => acc + curr, 0);
+};
 
 export const ReviewStep = (props: {
   confirm: () => void;
@@ -11,7 +57,25 @@ export const ReviewStep = (props: {
   setAttributes: Function;
   connection: Connection;
 }) => {
+  const [cost, setCost] = useState(0);
   const item = props.attributes.items?.[0];
+
+  useEffect(() => {
+    if (!item) {
+      return;
+    }
+    (async () => {
+      const accountStorageCosts = await calculateAuctionCreationCost(
+        props.connection,
+      );
+      // Ideally get filteredSigners, but from my testing they're usually 11 for this use case.
+      const recentBlockhash = await props.connection.getRecentBlockhash();
+      const signatureCost =
+        recentBlockhash.feeCalculator.lamportsPerSignature *
+        /* Sorry about the magic number, but got it from testing */ 11;
+      setCost((accountStorageCosts + signatureCost) / LAMPORTS_PER_SOL);
+    })();
+  }, []);
 
   return (
     <Space className="metaplex-fullwidth" direction="vertical">
@@ -35,6 +99,15 @@ export const ReviewStep = (props: {
                 ? 'Unique'
                 : props.attributes.editions
             }
+          />
+          <Divider />
+          <AmountLabel
+            title={
+              props.attributes.category === AuctionCategory.InstantSale
+                ? 'Cost to Sell'
+                : 'Cost to Create Auction'
+            }
+            amount={cost}
           />
         </Col>
       </Row>


### PR DESCRIPTION
On the last screen of listing in the area below copies put together a price summary of creating the listing that should: 
Show total cost of solana storage by getting the rent exempt fee for all accounts being created by the listing.
Show transaction cost with # transactions * per transaction cost.