### PR TITLE
fix / refactor:  re-work maxSupply in minting flow

### DIFF
--- a/js/packages/web/src/views/artCreate/index.tsx
+++ b/js/packages/web/src/views/artCreate/index.tsx
@@ -53,7 +53,6 @@ export const ArtCreateView = () => {
     seller_fee_basis_points: 0,
     creators: [],
     properties: {
-      maxSupply: 0,
       files: [],
       category: MetadataCategory.Image,
     },

--- a/js/packages/web/src/views/artCreate/infoStep.tsx
+++ b/js/packages/web/src/views/artCreate/infoStep.tsx
@@ -121,6 +121,16 @@ export const InfoStep = (props: {
 
               <label>
                 <h3>Maximum Supply</h3>
+                <p
+                  style={{
+                    opacity: '0.85',
+                    margin: '-4px 0 0',
+                    paddingBottom: '10px',
+                  }}
+                >
+                  <strong>NOTE:</strong> If this field is left blank, it will be
+                  possible to mint an unlimited number of editions of this NFT.
+                </p>
                 <Form.Item name={['properties', 'maxSupply']}>
                   <InputNumber
                     className="metaplex-fullwidth"

--- a/js/packages/web/src/views/artCreate/infoStep.tsx
+++ b/js/packages/web/src/views/artCreate/infoStep.tsx
@@ -82,7 +82,7 @@ export const InfoStep = (props: {
           props.confirm();
         }}
       >
-        <Row justify="space-between" align="middle" wrap={false}>
+        <Row justify="space-between" wrap={false}>
           <Col span={6}>
             {props.attributes.image && (
               <ArtCard
@@ -173,7 +173,6 @@ export const InfoStep = (props: {
                   <Form.Item name={['properties', 'maxSupply']}>
                     <InputNumber
                       className="metaplex-fullwidth"
-                      placeholder="Number of Editions"
                       defaultValue={1}
                       min={1}
                     />


### PR DESCRIPTION
Removes the default maxSupply setting of 0 (which was causing a bug when attempting to mint unlimited edition NFTs) and instead adds a note in the user flow to warn the user that, if maxSupply is left unset, it will be possible to mint an unlimited number of editions:

![Screen Shot 2021-12-23 at 11 17 03 AM](https://user-images.githubusercontent.com/58375830/147273465-6ef2f2bc-62dc-4186-9f32-ae44acec9c75.png)

