### PR TITLE
[Fix] Listings protection and opting to live when no auction cache found

### DIFF
--- a/js/packages/common/src/contexts/meta/loadAccounts.ts
+++ b/js/packages/common/src/contexts/meta/loadAccounts.ts
@@ -296,6 +296,10 @@ export const loadAccounts = async (
       const setMetadata = auctionCache.info.metadata.map(async metadataKey => {
         const metadata = state.metadataByMetadata[metadataKey];
 
+        if (!metadata) {
+          return Promise.resolve();
+        }
+
         let auctionMetadata =
           state.metadataByAuction[auctionCache.info.auction];
 

--- a/js/packages/web/src/components/AuctionRenderCard/index.tsx
+++ b/js/packages/web/src/components/AuctionRenderCard/index.tsx
@@ -12,7 +12,7 @@ export interface AuctionCard extends CardProps {
 
 export const AuctionRenderCard = (props: AuctionCard) => {
   const { auctionView } = props;
-  const id = auctionView.thumbnail.metadata.pubkey;
+  const id = auctionView.thumbnail?.metadata?.pubkey;
   const art = useArt(id);
   const name = art?.title || ' ';
 

--- a/js/packages/web/src/hooks/useAuctions.ts
+++ b/js/packages/web/src/hooks/useAuctions.ts
@@ -181,7 +181,9 @@ export const useInfiniteScrollAuctions = (view: View) => {
       const auctionManager = auctionManagersByAuction[a.pubkey];
       const cache = auctionCachesByAuctionManager[auctionManager.pubkey];
 
-      if (!cache) {
+      if (sale && !cache) {
+        return false;
+      } else if (!cache) {
         return active;
       }
 
@@ -289,8 +291,12 @@ export const useInfiniteScrollAuctions = (view: View) => {
       const storeAuctionManagers = Object.values(
         auctionManagersByAuction,
       ).filter(
-        am => am.info.store === storeAddress && auctions[am.info.auction],
+        am =>
+          am.info.store === storeAddress &&
+          auctions[am.info.auction] &&
+          am.info.key === MetaplexKey.AuctionManagerV2,
       );
+
       const initializedAuctions = storeAuctionManagers
         .map(am => auctions[am.info.auction])
         .filter(a => a.info.state > 0);
@@ -313,7 +319,7 @@ export const useInfiniteScrollAuctions = (view: View) => {
         ended: auctionDisplayOrders[View.ended].length,
       });
 
-      const auctionManagers = auctionDisplayOrders[view].map(
+      const auctionManagers = (auctionDisplayOrders[view] || []).map(
         auction => auctionManagersByAuction[auction.pubkey],
       );
 
@@ -618,11 +624,6 @@ export function processAccountsIntoAuctionView(
           view.participationItem)) &&
       view.vault
     );
-    if (
-      (!view.thumbnail || !view.thumbnail.metadata) &&
-      desiredState != AuctionViewState.Defective
-    )
-      return undefined;
 
     return view as AuctionView;
   }

--- a/js/packages/web/src/views/Listings/index.tsx
+++ b/js/packages/web/src/views/Listings/index.tsx
@@ -41,7 +41,7 @@ export const Listings = () => {
   });
 
   const showCount = (view: View) =>
-    auctionsCount[view] != null ? auctionsCount[view] : <Spin size="small" />;
+    auctionsCount[view] != null ? auctionsCount[view] : <Spin size="small" indicator={<LoadingOutlined />}  />;
   useEffect(() => {
     if (!view) {
       setSearchParams({ view: View.live });

--- a/js/packages/web/src/views/auction/index.tsx
+++ b/js/packages/web/src/views/auction/index.tsx
@@ -78,8 +78,8 @@ export const AuctionView = () => {
   const connection = useConnection();
   const { patchState } = useMeta();
   const [currentIndex, setCurrentIndex] = useState(0);
-  const art = useArt(auction?.thumbnail.metadata.pubkey);
-  const { ref, data } = useExtendedArt(auction?.thumbnail.metadata.pubkey);
+  const art = useArt(auction?.thumbnail?.metadata?.pubkey);
+  const { ref, data } = useExtendedArt(auction?.thumbnail?.metadata?.pubkey);
   const creators = useCreators(auction);
   const wallet = useWallet();
   let edition = '';


### PR DESCRIPTION
### Changes
- Filter out auction manager v1. Holaplex does not support this early version of auction managers.
- Handle metadata not existing on chain but being associated to an auction cache.
- Only consider listing for secondary listing when auction cache is present. Fallback to showing in live.
- Display listing when no nft associated. This is a bugged listing.


<img width="483" alt="Screen Shot 2021-12-29 at 12 15 02 PM" src="https://user-images.githubusercontent.com/2388118/147697149-c341fa6c-d40e-42b7-81f0-7b802874f568.png">
<img width="476" alt="Screen Shot 2021-12-29 at 12 15 21 PM" src="https://user-images.githubusercontent.com/2388118/147697156-a028ee9d-52f4-4def-9124-b2bdc4edfb96.png">

resolves
https://github.com/holaplex/metaplex/issues/188