### PR TITLE
[Fix] Allow User to Reclaim Instant Sale After Listing Settled

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -543,7 +543,7 @@ export const AuctionCard = ({
     ? Boolean(auctionView.myBidderPot?.info.emptied)
     : true;
   const doesInstantSaleHasNoItems =
-    isBidderPotEmpty &&
+    isBidderPotEmpty && auctionView?.myBidderMetadata?.info.cancelled &&
     auctionView.auctionManager.numWinners.toNumber() === bids.length;
 
   const shouldHideInstantSale =


### PR DESCRIPTION
### Issue

There is an edge case where a user buys an instant sale but the redeem instruction is not fired and the auctioneer closes out the listing. This triggers the hide actions logic but users should be able to see the redeem button even if the auctioneer closed out the listing.

### Changes

- Still show the listing actions for instant sale as long as the myBidder has not been closed out for the buyer.