### PR TITLE
Fix for primary sales funds distribution: simplified

### DIFF
--- a/js/packages/common/src/actions/metadata.ts
+++ b/js/packages/common/src/actions/metadata.ts
@@ -914,16 +914,28 @@ export async function mintNewEditionFromMasterEditionViaToken(
   );
 }
 
-export async function updatePrimarySaleHappenedViaToken(
+export function updatePrimarySaleHappenedViaToken(
   metadata: StringPublicKey,
   owner: StringPublicKey,
   tokenAccount: StringPublicKey,
   instructions: TransactionInstruction[],
 ) {
+  instructions.push(
+    createUpdatePrimarySaleHappenedViaTokenInstructions(
+      metadata,
+      owner,
+      tokenAccount,
+    ),
+  );
+}
+
+export function createUpdatePrimarySaleHappenedViaTokenInstructions(
+  metadata: StringPublicKey,
+  owner: StringPublicKey,
+  tokenAccount: StringPublicKey,
+) {
   const metadataProgramId = programIds().metadata;
-
   const data = Buffer.from([4]);
-
   const keys = [
     {
       pubkey: toPublicKey(metadata),
@@ -941,13 +953,11 @@ export async function updatePrimarySaleHappenedViaToken(
       isWritable: false,
     },
   ];
-  instructions.push(
-    new TransactionInstruction({
-      keys,
-      programId: toPublicKey(metadataProgramId),
-      data,
-    }),
-  );
+  return new TransactionInstruction({
+    keys,
+    programId: toPublicKey(metadataProgramId),
+    data,
+  });
 }
 
 export async function deprecatedCreateReservationList(

--- a/js/packages/web/src/actions/settle.ts
+++ b/js/packages/web/src/actions/settle.ts
@@ -63,7 +63,7 @@ export async function settle(
   await emptyPaymentAccountForAllTokens(connection, wallet, auctionView);
 }
 
-async function emptyPaymentAccountForAllTokens(
+export async function createEmptyPaymentAccountForAllTokensIX(
   connection: Connection,
   wallet: WalletSigner,
   auctionView: AuctionView,
@@ -184,6 +184,20 @@ async function emptyPaymentAccountForAllTokens(
     instructions.push(currInstrBatch);
   }
 
+  return { signers, instructions };
+}
+
+async function emptyPaymentAccountForAllTokens(
+  connection: Connection,
+  wallet: WalletSigner,
+  auctionView: AuctionView,
+) {
+  const { instructions, signers } =
+    await createEmptyPaymentAccountForAllTokensIX(
+      connection,
+      wallet,
+      auctionView,
+    );
   for (let i = 0; i < instructions.length; i++) {
     const instructionBatch = instructions[i];
     const signerBatch = signers[i];


### PR DESCRIPTION
This fix removes inserting the flipPrimarySaleHappened instructions in place and returns them so they can be added at the end of the array.