### PR TITLE
Fix: Prevent tick-related errors in listings & bidding

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -296,7 +296,7 @@ export const AuctionCard = ({
   // JS MODULO OPERATOR DOES NOT WORK HOW YOU EXPECT IT TO
   // BREAKS WITH FLOATS, MULTIPLY AWAY ALL FLOATS
   // see this for some info https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript
-  const multiplier = 1000000;
+  const multiplier = 1000;
   const tickSizeInvalid = !!(
     tickSize &&
     value &&

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -296,10 +296,11 @@ export const AuctionCard = ({
   // JS MODULO OPERATOR DOES NOT WORK HOW YOU EXPECT IT TO
   // BREAKS WITH FLOATS, MULTIPLY AWAY ALL FLOATS
   // see this for some info https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript
+  const multiplier = 1000000;
   const tickSizeInvalid = !!(
     tickSize &&
     value &&
-    (value * 100) % (fromLamports(tickSize) * 100) != 0
+    (value * multiplier) % (fromLamports(tickSize) * multiplier) != 0
   );
 
   const gapBidInvalid = useGapTickCheck(value, gapTick, gapTime, auctionView);

--- a/js/packages/web/src/views/auctionCreate/priceAuction.tsx
+++ b/js/packages/web/src/views/auctionCreate/priceAuction.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Space } from 'antd';
+import { Button, InputNumber, Space } from 'antd';
 import React, { useState } from 'react';
 import { AuctionCategory, AuctionState } from '.';
 
@@ -21,16 +21,14 @@ export const PriceAuction = (props: {
     }
   };
 
-  const handleInput = (inputString: string, isPrice: boolean) => {
-    const parsedFloat = parseFloat(inputString);
+  const handleInput = (input: number, isPrice: boolean) => {
     if (isPrice) {
-      setPrice(parsedFloat);
-      handlePriceError(parsedFloat, tickSize);
+      setPrice(input);
+      handlePriceError(input, tickSize);
     } else {
-      setTickSize(parsedFloat);
-      handlePriceError(price, parsedFloat);
+      setTickSize(input);
+      handlePriceError(price, input);
     }
-    return parsedFloat;
   };
 
   return (
@@ -47,22 +45,24 @@ export const PriceAuction = (props: {
             This is the fixed price that everybody will pay for your
             Participation NFT.
           </span>
-          <Input
-            type="number"
+          <InputNumber<number>
             min={0}
+            decimalSeparator="."
+            className="metaplex-fullwidth"
+            step="0.01"
             autoFocus
-            placeholder="Fixed Price"
-            prefix="◎"
-            suffix="SOL"
-            onChange={info => {
-              const parsedFloat = handleInput(info.target.value, true);
+            placeholder="Fixed Price in SOL"
+            onChange={price => {
+              handleInput(price, true);
               props.setAttributes({
                 ...props.attributes,
                 // Do both, since we know this is the only item being sold.
-                participationFixedPrice: parsedFloat,
-                priceFloor: parsedFloat,
+                participationFixedPrice: price,
+                priceFloor: price,
               });
             }}
+            precision={2}
+            formatter={x => (x ? `◎ ${x}` : '')}
           />
         </label>
       )}
@@ -70,39 +70,44 @@ export const PriceAuction = (props: {
         <label>
           <h3>Price Floor</h3>
           <p>This is the starting bid price for your auction.</p>
-          <Input
-            type="number"
+          <InputNumber<number>
             min={0}
+            decimalSeparator="."
+            className="metaplex-fullwidth"
+            step="0.01"
             autoFocus
-            placeholder="Price"
-            prefix="◎"
-            suffix="SOL"
-            onChange={info => {
-              const parsedFloat = handleInput(info.target.value, true);
+            placeholder="Price in SOL"
+            onChange={price => {
+              handleInput(price, true);
               props.setAttributes({
                 ...props.attributes,
-                priceFloor: parsedFloat,
+                priceFloor: price,
               });
             }}
+            precision={2}
+            formatter={x => (x ? `◎ ${x}` : '')}
           />
         </label>
       )}
       <label>
         <h3>Tick Size</h3>
         <p>All bids must fall within this price increment.</p>
-        <Input
-          type="number"
+        <InputNumber<number>
           min={0}
+          decimalSeparator="."
+          className="metaplex-fullwidth"
+          step="0.01"
+          autoFocus
           placeholder="Tick size in SOL"
-          prefix="◎"
-          suffix="SOL"
-          onChange={info => {
-            const parsedFloat = handleInput(info.target.value, false);
+          onChange={tick => {
+            handleInput(tick, false);
             props.setAttributes({
               ...props.attributes,
-              priceTick: parsedFloat,
+              priceTick: tick,
             });
           }}
+          precision={2}
+          formatter={x => (x ? `◎ ${x}` : '')}
         />
       </label>
 

--- a/js/packages/web/src/views/auctionCreate/priceAuction.tsx
+++ b/js/packages/web/src/views/auctionCreate/priceAuction.tsx
@@ -1,4 +1,5 @@
-import { Button, InputNumber, Space } from 'antd';
+import { Button, InputNumber, Space, Form } from 'antd';
+import { useForm } from 'antd/lib/form/Form';
 import React, { useState } from 'react';
 import { AuctionCategory, AuctionState } from '.';
 
@@ -10,24 +11,12 @@ export const PriceAuction = (props: {
   type InputState = number | null;
   const [price, setPrice] = useState<InputState>(null);
   const [tickSize, setTickSize] = useState<InputState>(null);
-  const [priceError, setPriceError] = useState(false);
+  const [form] = useForm();
 
-  const handlePriceError = (price: InputState, tick: InputState) => {
+  const checkForPriceError = (price: InputState, tick: InputState) => {
     const multiplier = 1000;
-    if (tick && price && (price * multiplier) % (tick * multiplier) !== 0) {
-      setPriceError(true);
-    } else {
-      setPriceError(false);
-    }
-  };
-
-  const handleInput = (input: number, isPrice: boolean) => {
-    if (isPrice) {
-      setPrice(input);
-      handlePriceError(input, tickSize);
-    } else {
-      setTickSize(input);
-      handlePriceError(price, input);
+    if (price && tick && (price * multiplier) % (tick * multiplier) !== 0) {
+      throw new Error();
     }
   };
 
@@ -38,93 +27,147 @@ export const PriceAuction = (props: {
         <p>Set the price for your auction.</p>
       </div>
 
-      {props.attributes.category === AuctionCategory.Open && (
-        <label>
-          <h3>Price</h3>
-          <p>
-            This is the fixed price that everybody will pay for your
-            Participation NFT.
-          </p>
-          <InputNumber<number>
-            min={0}
-            decimalSeparator="."
-            className="metaplex-fullwidth"
-            step="0.01"
-            autoFocus
-            placeholder="Fixed Price in SOL"
-            onChange={price => {
-              handleInput(price, true);
-              props.setAttributes({
-                ...props.attributes,
-                // Do both, since we know this is the only item being sold.
-                participationFixedPrice: price,
-                priceFloor: price,
-              });
-            }}
-            precision={2}
-            formatter={x => (x ? `◎ ${x}` : '')}
-          />
-        </label>
-      )}
-      {props.attributes.category !== AuctionCategory.Open && (
-        <label>
-          <h3>Price Floor</h3>
-          <p>This is the starting bid price for your auction.</p>
-          <InputNumber<number>
-            min={0}
-            decimalSeparator="."
-            className="metaplex-fullwidth"
-            step="0.01"
-            autoFocus
-            placeholder="Price in SOL"
-            onChange={price => {
-              handleInput(price, true);
-              props.setAttributes({
-                ...props.attributes,
-                priceFloor: price,
-              });
-            }}
-            precision={2}
-            formatter={x => (x ? `◎ ${x}` : '')}
-          />
-        </label>
-      )}
-      <label>
-        <h3 className="metaplex-margin-top-4">Tick Size</h3>
-        <p>All bids must fall within this price increment.</p>
-        <InputNumber<number>
-          min={0}
-          decimalSeparator="."
-          className="metaplex-fullwidth"
-          step="0.01"
-          placeholder="Tick size in SOL"
-          onChange={tick => {
-            handleInput(tick, false);
-            props.setAttributes({
-              ...props.attributes,
-              priceTick: tick,
-            });
-          }}
-          precision={2}
-          formatter={x => (x ? `◎ ${x}` : '')}
-        />
-      </label>
-
-      {priceError && (
-        <div className="error-message">
-          Starting price must be an exact multiple of the tick size!
-        </div>
-      )}
-
-      <Button
-        className="metaplex-fullwidth metaplex-margin-top-4 metaplex-margin-bottom-4"
-        type="primary"
-        size="large"
-        onClick={props.confirm}
-        disabled={priceError}
+      <Form
+        form={form}
+        onFinish={() => {
+          form.validateFields(['price', 'tickSize']).then(props.confirm);
+        }}
       >
-        Continue
-      </Button>
+        {props.attributes.category === AuctionCategory.Open && (
+          <Form.Item
+            name="price"
+            rules={[
+              {
+                message:
+                  'Starting price must be an exact multiple of the tick size!',
+                validator: async (_, price) => {
+                  checkForPriceError(price, tickSize);
+                },
+              },
+              {
+                required: true,
+                message: 'Price is required.',
+              },
+            ]}
+          >
+            <label>
+              <h3>Price</h3>
+              <p>
+                This is the fixed price that everybody will pay for your
+                Participation NFT.
+              </p>
+              <div className="metaplex-flex metaplex-align-items-center metaplex-gap-2">
+                ◎
+                <InputNumber<number>
+                  min={0}
+                  decimalSeparator="."
+                  className="metaplex-fullwidth"
+                  step="0.01"
+                  autoFocus
+                  placeholder="Fixed Price in SOL"
+                  onChange={price => {
+                    setPrice(price);
+                    props.setAttributes({
+                      ...props.attributes,
+                      // Do both, since we know this is the only item being sold.
+                      participationFixedPrice: price,
+                      priceFloor: price,
+                    });
+                  }}
+                  precision={2}
+                />
+              </div>
+            </label>
+          </Form.Item>
+        )}
+        {props.attributes.category !== AuctionCategory.Open && (
+          <Form.Item
+            name="price"
+            rules={[
+              {
+                message:
+                  'Starting price must be an exact multiple of the tick size!',
+                validator: async (_, price) => {
+                  checkForPriceError(price, tickSize);
+                },
+              },
+              {
+                required: true,
+                message: 'Price is required.',
+              },
+            ]}
+          >
+            <label>
+              <h3>Price Floor</h3>
+              <p>This is the starting bid price for your auction.</p>
+              <div className="metaplex-flex metaplex-align-items-center metaplex-gap-2">
+                ◎
+                <InputNumber<number>
+                  min={0}
+                  decimalSeparator="."
+                  className="metaplex-fullwidth"
+                  step="0.01"
+                  autoFocus
+                  placeholder="Price in SOL"
+                  onChange={price => {
+                    setPrice(price);
+                    props.setAttributes({
+                      ...props.attributes,
+                      priceFloor: price,
+                    });
+                  }}
+                  precision={2}
+                />
+              </div>
+            </label>
+          </Form.Item>
+        )}
+        <Form.Item
+          name="tickSize"
+          rules={[
+            {
+              message:
+                'Starting price must be an exact multiple of the tick size!',
+              validator: async (_, tickSize) => {
+                checkForPriceError(price, tickSize);
+              },
+            },
+          ]}
+        >
+          <label>
+            <h3 className="metaplex-margin-top-4">Tick Size</h3>
+            <p>All bids must fall within this price increment.</p>
+            <div className="metaplex-flex metaplex-align-items-center metaplex-gap-2">
+              ◎
+              <InputNumber<number>
+                min={0}
+                decimalSeparator="."
+                className="metaplex-fullwidth"
+                step="0.01"
+                placeholder="Tick size in SOL"
+                onChange={tick => {
+                  setTickSize(tick);
+                  props.setAttributes({
+                    ...props.attributes,
+                    priceTick: tick,
+                  });
+                }}
+                precision={2}
+              />
+            </div>
+          </label>
+        </Form.Item>
+        <Form.Item>
+          <Button
+            className="metaplex-fullwidth metaplex-margin-top-4 metaplex-margin-bottom-4"
+            type="primary"
+            size="large"
+            htmlType="submit"
+          >
+            Continue
+          </Button>
+        </Form.Item>
+      </Form>
     </Space>
   );
 };

--- a/js/packages/web/src/views/auctionCreate/priceAuction.tsx
+++ b/js/packages/web/src/views/auctionCreate/priceAuction.tsx
@@ -40,11 +40,11 @@ export const PriceAuction = (props: {
 
       {props.attributes.category === AuctionCategory.Open && (
         <label>
-          <span>Price</span>
-          <span>
+          <h3>Price</h3>
+          <p>
             This is the fixed price that everybody will pay for your
             Participation NFT.
-          </span>
+          </p>
           <InputNumber<number>
             min={0}
             decimalSeparator="."
@@ -90,7 +90,7 @@ export const PriceAuction = (props: {
         </label>
       )}
       <label>
-        <h3>Tick Size</h3>
+        <h3 className="metaplex-margin-top-4">Tick Size</h3>
         <p>All bids must fall within this price increment.</p>
         <InputNumber<number>
           min={0}

--- a/js/packages/web/src/views/auctionCreate/priceAuction.tsx
+++ b/js/packages/web/src/views/auctionCreate/priceAuction.tsx
@@ -97,7 +97,6 @@ export const PriceAuction = (props: {
           decimalSeparator="."
           className="metaplex-fullwidth"
           step="0.01"
-          autoFocus
           placeholder="Tick size in SOL"
           onChange={tick => {
             handleInput(tick, false);

--- a/js/packages/web/src/views/auctionCreate/priceAuction.tsx
+++ b/js/packages/web/src/views/auctionCreate/priceAuction.tsx
@@ -159,7 +159,7 @@ export const PriceAuction = (props: {
         </Form.Item>
         <Form.Item>
           <Button
-            className="metaplex-fullwidth metaplex-margin-top-4 metaplex-margin-bottom-4"
+            className="metaplex-fullwidth metaplex-margin-y-4"
             type="primary"
             size="large"
             htmlType="submit"

--- a/js/packages/web/src/views/auctionCreate/priceAuction.tsx
+++ b/js/packages/web/src/views/auctionCreate/priceAuction.tsx
@@ -13,7 +13,7 @@ export const PriceAuction = (props: {
   const [priceError, setPriceError] = useState(false);
 
   const handlePriceError = (price: InputState, tick: InputState) => {
-    const multiplier = 1000000;
+    const multiplier = 1000;
     if (tick && price && (price * multiplier) % (tick * multiplier) !== 0) {
       setPriceError(true);
     } else {

--- a/js/packages/web/src/views/auctionCreate/priceAuction.tsx
+++ b/js/packages/web/src/views/auctionCreate/priceAuction.tsx
@@ -1,6 +1,6 @@
 import { Button, InputNumber, Space, Form } from 'antd';
 import { useForm } from 'antd/lib/form/Form';
-import React, { useState } from 'react';
+import React from 'react';
 import { AuctionCategory, AuctionState } from '.';
 
 export const PriceAuction = (props: {
@@ -8,9 +8,7 @@ export const PriceAuction = (props: {
   setAttributes: (attr: AuctionState) => void;
   confirm: () => void;
 }) => {
-  type InputState = number | null;
-  const [price, setPrice] = useState<InputState>(null);
-  const [tickSize, setTickSize] = useState<InputState>(null);
+  type InputState = number | undefined;
   const [form] = useForm();
 
   const checkForPriceError = (price: InputState, tick: InputState) => {
@@ -41,7 +39,7 @@ export const PriceAuction = (props: {
                 message:
                   'Starting price must be an exact multiple of the tick size!',
                 validator: async (_, price) => {
-                  checkForPriceError(price, tickSize);
+                  checkForPriceError(price, props.attributes.priceTick);
                 },
               },
               {
@@ -66,7 +64,6 @@ export const PriceAuction = (props: {
                   autoFocus
                   placeholder="Fixed Price in SOL"
                   onChange={price => {
-                    setPrice(price);
                     props.setAttributes({
                       ...props.attributes,
                       // Do both, since we know this is the only item being sold.
@@ -88,7 +85,7 @@ export const PriceAuction = (props: {
                 message:
                   'Starting price must be an exact multiple of the tick size!',
                 validator: async (_, price) => {
-                  checkForPriceError(price, tickSize);
+                  checkForPriceError(price, props.attributes.priceTick);
                 },
               },
               {
@@ -110,7 +107,6 @@ export const PriceAuction = (props: {
                   autoFocus
                   placeholder="Price in SOL"
                   onChange={price => {
-                    setPrice(price);
                     props.setAttributes({
                       ...props.attributes,
                       priceFloor: price,
@@ -129,7 +125,7 @@ export const PriceAuction = (props: {
               message:
                 'Starting price must be an exact multiple of the tick size!',
               validator: async (_, tickSize) => {
-                checkForPriceError(price, tickSize);
+                checkForPriceError(props.attributes.priceFloor, tickSize);
               },
             },
           ]}
@@ -146,7 +142,6 @@ export const PriceAuction = (props: {
                 step="0.01"
                 placeholder="Tick size in SOL"
                 onChange={tick => {
-                  setTickSize(tick);
                   props.setAttributes({
                     ...props.attributes,
                     priceTick: tick,

--- a/js/packages/web/src/views/auctionCreate/styles.less
+++ b/js/packages/web/src/views/auctionCreate/styles.less
@@ -4,3 +4,11 @@
   flex-direction: column;
   align-items: center;
 }
+
+.error-message {
+  background-color: #500a;
+  color: white;
+  border: 1px solid @theme-color-border;
+  padding: 1rem 1.5rem;
+  margin-top: 1rem;
+}

--- a/js/packages/web/src/views/auctionCreate/styles.less
+++ b/js/packages/web/src/views/auctionCreate/styles.less
@@ -4,11 +4,3 @@
   flex-direction: column;
   align-items: center;
 }
-
-.error-message {
-  background-color: #500a;
-  color: white;
-  border: 1px solid @theme-color-border;
-  padding: 1rem 1.5rem;
-  margin-top: 1rem;
-}


### PR DESCRIPTION
## Problem:

- Lack of form validation is causing unnecessary tick-related errors

## This Fix:

- Lowers the permitted precision (decimal increment) of the price and tick size inputs to match bidding precision
- Adds form validation to make sure the price is an exact multiple of the tick size when creating a listing (and throws an error / disables the submit button if not)