### PR TITLE
Adjust store label from Metaplex -> Holaplex

### DIFF
--- a/js/packages/web/src/constants/labels.ts
+++ b/js/packages/web/src/constants/labels.ts
@@ -1,5 +1,5 @@
 export const LABELS = {
-  STORE_NAME: 'Metaplex',
+  STORE_NAME: 'Holaplex',
   CONNECT_LABEL: 'Connect Wallet',
   GIVE_SOL: 'Give me SOL',
   FAUCET_INFO:


### PR DESCRIPTION
Edited the store label from `metaplex` to `holaplex`, should replace all instances like this.

![image](https://user-images.githubusercontent.com/313060/150398148-192365ea-ae42-43c4-9ba1-b050d2984d54.png)
