### PR TITLE
miscellaneous revisions

### DIFF
--- a/js/packages/web/src/components/AppBar/styles.less
+++ b/js/packages/web/src/components/AppBar/styles.less
@@ -12,7 +12,6 @@
 
   @media screen and (max-width: 700px) {
     flex-direction: column-reverse;
-    gap: 1rem;
   }
 }
 
@@ -20,7 +19,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1.5rem;
-  height: 1.5rem;
   margin-top: 0.5rem;
 
   @media (max-width: 800px) {
@@ -60,19 +58,27 @@
 
 .app-bar-left-wrapper {
   display: flex;
-  gap: 2rem;
+  // gap: 2rem;
   align-items: center;
 
   @media (max-width: 700px) {
     flex-direction: column-reverse;
+    margin-top: 1rem;
   }
 }
 
 .app-bar-logo-wrapper {
+  margin-right: 1.5rem;
+
   @media screen and (max-width: 800px) {
     &.hide {
       display: none;
     }
+  }
+
+  @media screen and (max-width: 700px) {
+    margin-right: 0;
+    margin-top: 2rem;
   }
 }
 
@@ -85,6 +91,6 @@
     flex-direction: column-reverse;
     width: 120px;
     height: 120px;
-    margin: -0.15rem 0 0 2px;
+    margin: -0.15rem 0 0;
   }
 }

--- a/js/packages/web/src/components/AppBar/styles.less
+++ b/js/packages/web/src/components/AppBar/styles.less
@@ -58,7 +58,6 @@
 
 .app-bar-left-wrapper {
   display: flex;
-  // gap: 2rem;
   align-items: center;
 
   @media (max-width: 700px) {

--- a/js/packages/web/src/styles/styles.less
+++ b/js/packages/web/src/styles/styles.less
@@ -230,3 +230,7 @@ h6 {
   line-height: 1;
   font-weight: bold;
 }
+
+a {
+  color: @theme-color-text;
+}

--- a/js/packages/web/src/views/artCreate/categoryStep.tsx
+++ b/js/packages/web/src/views/artCreate/categoryStep.tsx
@@ -8,10 +8,6 @@ export const CategoryStep = (props: {
   return (
     <Space className="metaplex-fullwidth" direction="vertical">
       <h2>Create a new item</h2>
-      <p>
-        First time creating on Metaplex?{' '}
-        <a href="#">Read our creators’ guide.</a>
-      </p>
       <Row>
         <Col span={10}>
           <Space className="metaplex-fullwidth" direction="vertical">

--- a/js/packages/web/src/views/artCreate/launchStep.tsx
+++ b/js/packages/web/src/views/artCreate/launchStep.tsx
@@ -93,14 +93,6 @@ export const LaunchStep = (props: {
       >
         Pay with SOL
       </Button>
-      <Button
-        disabled={true}
-        className="metaplex-fullwidth"
-        size="large"
-        onClick={props.confirm}
-      >
-        Pay with Credit Card
-      </Button>
     </Space>
   );
 };

--- a/js/packages/web/src/views/artworks/index.tsx
+++ b/js/packages/web/src/views/artworks/index.tsx
@@ -45,12 +45,14 @@ export const ArtworksView = () => {
 
   return (
     <>
-      <Row justify="space-between" align="middle">
+      <div className="metaplex-flex metaplex-align-items-center metaplex-justify-content-sb metaplex-margin-bottom-8 metaplex-gap-4 metaplex-flex-wrap">
         <h2>Owned Artwork</h2>
         <Link to="/listings/new/0">
-          <Button size="large" type="primary">Sell NFT</Button>
+          <Button size="large" type="primary">
+            Sell NFT
+          </Button>
         </Link>
-      </Row>
+      </div>
       <Row>
         <Col span={24}>
           <MetaplexMasonry>

--- a/js/packages/web/src/views/auction/index.tsx
+++ b/js/packages/web/src/views/auction/index.tsx
@@ -183,7 +183,7 @@ export const AuctionView = () => {
         </>
       )}
 
-      {attributes && (
+      {attributes && attributes.length > 0 && (
         <div>
           <h3 className="info-header">Attributes</h3>
           <List grid={{ column: 4 }}>

--- a/js/packages/web/src/views/auction/styles.less
+++ b/js/packages/web/src/views/auction/styles.less
@@ -70,6 +70,10 @@
   margin: 0 0 2rem;
   justify-content: space-between;
   gap: 2rem;
+
+  * {
+    word-break: break-all;
+  }
 }
 
 .info-outer-wrapper {


### PR DESCRIPTION
resolves #261, including:
- "Attributes" should be conditionally rendered (only show when there are attributes) on listing pages
- Remove "Pay with Credit Card" button
- Fix Safari header margin bug (look at topnav on Safari mobile view)
- Fix metadata storefront hyperlink colors (using secondary color doesn't work on some stores, so just use main font color with underline)
- Remove "Read our creator's guide"
- Long titles need word-wrap (example: https://samcook.holaplex.dev/listings/BPWBHutPVJjFco14hySHiCoQu8kMmfkdjAtcs9jYmCPj on DEVNET breaks on tablet size)
- Add margin below header row on "Owned" tab
