### PR TITLE
Fix more tick size bidding errors

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -331,7 +331,7 @@ export const AuctionCard = ({
     );
 
     if (tickSize) {
-      minBid += tickSize.toNumber() / LAMPORTS_PER_SOL;
+      minBid += fromLamports(tickSize) / LAMPORTS_PER_SOL;
     }
   }
 
@@ -355,6 +355,12 @@ export const AuctionCard = ({
     belowMinBid ||
     loading ||
     !accountByMint.get(QUOTE_MINT.toBase58());
+
+  const minNextBid = (
+    tickSize
+      ? (minBid * multiplier + fromLamports(tickSize) * multiplier) / multiplier
+      : minBid
+  ).toFixed(2);
 
   useEffect(() => {
     if (wallet.connected) {
@@ -799,7 +805,7 @@ export const AuctionCard = ({
             onChange={setValue}
             precision={2}
             formatter={value => (value ? `◎ ${value}` : '')}
-            placeholder={`Bid ${minBid} SOL or more`}
+            placeholder={`Bid ${minNextBid} SOL or more`}
           />
         </Col>
         <Col flex="0 0 auto">
@@ -868,7 +874,7 @@ export const AuctionCard = ({
               )}
               {value !== undefined && !!belowMinBid && (
                 <Text className="danger" type="danger">
-                  The bid must be at least {minBid} SOL.
+                  The bid must be at least {minNextBid} SOL.
                 </Text>
               )}
               {gapBidInvalid && (

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -335,10 +335,20 @@ export const AuctionCard = ({
     }
   }
 
+  const isFirstBid = !auctionView.auction.info.bidState.bids.length;
+
   const belowMinBid =
     value &&
     minBid &&
-    value * multiplier < parseFloat(minBid.toFixed(2)) * multiplier;
+    (isFirstBid
+      ? value * multiplier < parseFloat(minBid.toFixed(2)) * multiplier
+      : value * multiplier <= parseFloat(minBid.toFixed(2)) * multiplier);
+
+  const minNextBid = isFirstBid
+    ? minBid.toFixed(2)
+    : !tickSize
+    ? parseFloat(minBid.toFixed(2)) + 0.01
+    : parseFloat(minBid.toFixed(2)) + fromLamports(tickSize);
 
   const biddingPower =
     balance.balance +
@@ -802,7 +812,7 @@ export const AuctionCard = ({
             onChange={setValue}
             precision={2}
             formatter={value => (value ? `◎ ${value}` : '')}
-            placeholder={`Bid ${minBid.toFixed(2)} SOL or more`}
+            placeholder={`Bid ${minNextBid} SOL or more`}
           />
         </Col>
         <Col flex="0 0 auto">
@@ -871,7 +881,7 @@ export const AuctionCard = ({
               )}
               {value !== undefined && !!belowMinBid && (
                 <Text className="danger" type="danger">
-                  The bid must be at least {minBid.toFixed(2)} SOL.
+                  The bid must be at least {minNextBid} SOL.
                 </Text>
               )}
               {gapBidInvalid && (

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -335,7 +335,10 @@ export const AuctionCard = ({
     }
   }
 
-  const belowMinBid = value && minBid && value < minBid;
+  const belowMinBid =
+    value &&
+    minBid &&
+    value * multiplier < parseFloat(minBid.toFixed(2)) * multiplier;
 
   const biddingPower =
     balance.balance +
@@ -355,12 +358,6 @@ export const AuctionCard = ({
     belowMinBid ||
     loading ||
     !accountByMint.get(QUOTE_MINT.toBase58());
-
-  const minNextBid = (
-    tickSize
-      ? (minBid * multiplier + fromLamports(tickSize) * multiplier) / multiplier
-      : minBid
-  ).toFixed(2);
 
   useEffect(() => {
     if (wallet.connected) {
@@ -805,7 +802,7 @@ export const AuctionCard = ({
             onChange={setValue}
             precision={2}
             formatter={value => (value ? `◎ ${value}` : '')}
-            placeholder={`Bid ${minNextBid} SOL or more`}
+            placeholder={`Bid ${minBid.toFixed(2)} SOL or more`}
           />
         </Col>
         <Col flex="0 0 auto">
@@ -874,7 +871,7 @@ export const AuctionCard = ({
               )}
               {value !== undefined && !!belowMinBid && (
                 <Text className="danger" type="danger">
-                  The bid must be at least {minNextBid} SOL.
+                  The bid must be at least {minBid.toFixed(2)} SOL.
                 </Text>
               )}
               {gapBidInvalid && (

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -337,18 +337,15 @@ export const AuctionCard = ({
 
   const isFirstBid = !auctionView.auction.info.bidState.bids.length;
 
-  const belowMinBid =
-    value &&
-    minBid &&
-    (isFirstBid
-      ? value * multiplier < parseFloat(minBid.toFixed(2)) * multiplier
-      : value * multiplier <= parseFloat(minBid.toFixed(2)) * multiplier);
-
   const minNextBid = isFirstBid
     ? minBid.toFixed(2)
     : !tickSize
-    ? parseFloat(minBid.toFixed(2)) + 0.01
-    : parseFloat(minBid.toFixed(2)) + fromLamports(tickSize);
+    ? (minBid + 0.01).toFixed(2)
+    : (minBid + fromLamports(tickSize)).toFixed(2);
+
+  const belowMinBid = value && minBid && value < parseFloat(minNextBid);
+
+  console.log('joe', value, parseFloat(minNextBid));
 
   const biddingPower =
     balance.balance +
@@ -874,14 +871,14 @@ export const AuctionCard = ({
                   bidding power is {biddingPower} SOL.
                 </Text>
               )}
-              {!!value && tickSizeInvalid && tickSize && (
-                <Text className="danger" type="danger">
-                  Tick size is ◎{tickSize.toNumber() / LAMPORTS_PER_SOL}.
-                </Text>
-              )}
               {value !== undefined && !!belowMinBid && (
                 <Text className="danger" type="danger">
                   The bid must be at least {minNextBid} SOL.
+                </Text>
+              )}
+              {!!value && tickSizeInvalid && tickSize && (
+                <Text className="danger" type="danger">
+                  Tick size is ◎{tickSize.toNumber() / LAMPORTS_PER_SOL}.
                 </Text>
               )}
               {gapBidInvalid && (

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -345,8 +345,6 @@ export const AuctionCard = ({
 
   const belowMinBid = value && minBid && value < parseFloat(minNextBid);
 
-  console.log('joe', value, parseFloat(minNextBid));
-
   const biddingPower =
     balance.balance +
     (auctionView.myBidderMetadata &&


### PR DESCRIPTION
- Fixes several remaining tick size related bugs
- Improves quality and accuracy of error messages. For example:
  - When there is a tick size, the minimum bid amount now shows the prior bid + the tick size
  - Numbers in error messages are now limited to two decimal places, same as the allowed # of decimal places in the bid input box
- Now accurately accounts for the following auction states:
  - First bid
  - Not first bid / has tick size
  - Not first bid / no tick size

Fixes #264 