### PR TITLE
Fix offset == -1 bug in cacheAllAuctions.

### DIFF
--- a/js/packages/web/src/actions/cacheAllAuctions.ts
+++ b/js/packages/web/src/actions/cacheAllAuctions.ts
@@ -50,7 +50,7 @@ export async function cacheAllAuctions(
     let offset = 0;
 
     if (activeIndex && cacheExists) {
-      offset = findIndex(activeIndex.info.auctionCaches, pubkey => {
+      const found = findIndex(activeIndex.info.auctionCaches, pubkey => {
         const cache = auctionCaches[pubkey];
 
         return (
@@ -58,6 +58,8 @@ export async function cacheAllAuctions(
           cache.info.timestamp.toNumber()
         );
       });
+
+      offset = found < 0 ? activeIndex.info.auctionCaches.length : found;
     }
 
     const { instructions, signers } = await cacheAuctionIndexer(

--- a/js/packages/web/src/actions/cacheAuctionIndexer.ts
+++ b/js/packages/web/src/actions/cacheAuctionIndexer.ts
@@ -48,7 +48,7 @@ export async function cacheAuctionIndexer(
 
   if (storeIndexer.length > 0) {
     above = storeIndexer[0].info.auctionCaches[offset];
-    below = below = storeIndexer[0].info.auctionCaches[offset - 1];
+    below = storeIndexer[0].info.auctionCaches[offset - 1];
   }
 
   const storeIndexKey = await getStoreIndexer(0);

--- a/js/packages/web/src/views/admin/index.tsx
+++ b/js/packages/web/src/views/admin/index.tsx
@@ -465,10 +465,9 @@ function InnerAdminView({
             <h3>Cache Auctions</h3>
             <p>
               Activate your storefront listing caches by pressing &ldquo;build
-              cache&rdquo;. This will reduce page load times for your
-              listings. Your storefront will start looking up listing using
-              the cache on November 17th. To preview the speed improvement
-              visit the Holaplex{' '}
+              cache&rdquo;. This will reduce page load times for your listings.
+              Your storefront will start looking up listing using the cache on
+              November 17th. To preview the speed improvement visit the Holaplex{' '}
               <a
                 rel="noopener noreferrer"
                 target="_blank"
@@ -493,15 +492,17 @@ function InnerAdminView({
                   onClick={async () => {
                     setCachingAuctions(true);
 
-                    await cacheAllAuctions(
-                      wallet,
-                      connection,
-                      auctionManagersToCache,
-                      auctionCaches,
-                      storeIndexer,
-                    );
-
-                    setCachingAuctions(false);
+                    try {
+                      await cacheAllAuctions(
+                        wallet,
+                        connection,
+                        auctionManagersToCache,
+                        auctionCaches,
+                        storeIndexer,
+                      );
+                    } finally {
+                      setCachingAuctions(false);
+                    }
                   }}
                 >
                   Build Cache


### PR DESCRIPTION
This fixes an obscure bug where caching the oldest auction in a store index page produced an invalid invocation of `SetStoreIndex`.  There's a [sister PR](https://github.com/metaplex-foundation/metaplex-program-library/pull/183) open for the instruction itself, which also does not handle this edge case correctly.  I'll mark this PR as ready for review once the MPL PR is good to go.