### PR TITLE
Remove paid participation NFT option

### DIFF
--- a/js/packages/web/src/views/auctionCreate/participationStep.tsx
+++ b/js/packages/web/src/views/auctionCreate/participationStep.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Space } from 'antd';
+import { Button, Space } from 'antd';
 import React from 'react';
 import { AuctionState } from '.';
 import { SafetyDepositDraft } from '../../actions/createAuctionManager';
@@ -40,27 +40,9 @@ export const ParticipationStep = (props: {
         Select Participation NFT
       </ArtSelector>
 
-      <label>
-        <h3>Price</h3>
-        <p>
-          This is an optional fixed price that non-winners will pay for your
-          Participation NFT.
-        </p>
-        <Input
-          type="number"
-          min={0}
-          autoFocus
-          placeholder="Fixed Price"
-          prefix="◎"
-          suffix="SOL"
-          onChange={info =>
-            props.setAttributes({
-              ...props.attributes,
-              participationFixedPrice: parseFloat(info.target.value),
-            })
-          }
-        />
-      </label>
+      <p>
+        NOTE: Participation NFTs will be provided free of charge to bidders.
+      </p>
 
       <Button
         className="metaplex-fullwidth"

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1885,10 +1885,10 @@
   dependencies:
     async-retry "^1.3.3"
 
-"@holaplex/ui@^0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@holaplex/ui/-/ui-0.0.25.tgz#86ca701249b4a40901f90e07ce71923c7ddb65f2"
-  integrity sha512-uKhXRylNjkS2busJet3vl5vsfPbgcS/hMdiY3lJC3YIMH5eppoGAcBElWPvmAVF6z9I0swk69FFxz7kieT59ag==
+"@holaplex/ui@^0.0.26":
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/@holaplex/ui/-/ui-0.0.26.tgz#bc67d4f4ff018ce81b3fd896dfc81ad51b41f56c"
+  integrity sha512-HP4vltTbKEznRitmwq1UWxRRuZEGstDnhySW5tmcsUwdJXoCUY2CxyD10uPwPrEOaCdYyVRQi7sjV3WaziXIbA==
   dependencies:
     "@holaplex/js" "^4.3.3"
     "@metaplex/js" "^4.11.3"


### PR DESCRIPTION
Removes option of setting a price for participation NFTs in listing flow due to current bugs related to redemption of participation NFT funds from escrow

## New view:
![Screen Shot 2022-02-07 at 3 56 57 PM](https://user-images.githubusercontent.com/58375830/152879433-c0024dab-86a0-45e2-a762-5c1e8f0d6ee9.png)
