### PR TITLE
add hidden listings filter in useGroupedAuctions hook

### DIFF
--- a/js/packages/web/src/hooks/useAuctions.ts
+++ b/js/packages/web/src/hooks/useAuctions.ts
@@ -214,15 +214,23 @@ export const useGroupedAuctions = () => {
         .filter(am => am.info.state.safetyConfigItemsValidated.toNumber())
         .map(am => auctions[am.info.auction]);
 
+      const hiddenListings = ['7jBFUWrdm1SzL2u71Vz9dFAbjbjXMG7pBpjEVmBV5h85'];
+
+      const isHidden = (x: ParsedAccount<AuctionData>) =>
+        !hiddenListings.includes(x.pubkey);
+
       const groups = {
         live: initializedAuctions
           .filter(isActiveSale(false))
+          .filter(isHidden)
           .sort(sortByEndingSoon),
         ended: initializedAuctions
           .filter(a => a.info.state === 2)
+          .filter(isHidden)
           .sort(sortByRecentlyEnded),
         resale: initializedAuctions
           .filter(isActiveSale(true))
+          .filter(isHidden)
           .sort(sortByRecentlyEnded),
       };
 


### PR DESCRIPTION
Adds the ability to hardcode a listing pubkey to be filtered out of the listings shown on the storefront view.