### PR TITLE
Remove duplicate Crossmint button when no wallet connected

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -1123,7 +1123,6 @@ export const AuctionCard = ({
                     Connect wallet to{' '}
                     {auctionView.isInstantSale ? 'purchase' : 'place bid'}
                   </Button>)}
-                  {maybeCrossMintButton(auctionView, storefront)}
               </>
             )}
 
@@ -1134,7 +1133,7 @@ export const AuctionCard = ({
                 </>
               )}
             {showPlaceBidButton && PlaceBidBtn}
-            {actuallyShowPlaceBidUI && PlaceBidUI} 
+            {actuallyShowPlaceBidUI && PlaceBidUI}
             {maybeCrossMintButton(auctionView, storefront)}
           </>
         )}


### PR DESCRIPTION
Bug was introduced during a recent refactor of the button