### PR TITLE
Add better metadata according to auction metadata

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -235,9 +235,15 @@ function useAuctionExtended(
 export const AuctionCard = ({
   auctionView,
   hideDefaultAction,
+  artDescription,
+  artTitle,
+  artImage
 }: {
   auctionView: AuctionView;
   hideDefaultAction?: boolean;
+  artDescription?: string
+  artTitle?: string
+  artImage?: string
 }) => {
   const { storefront } = useStore();
   const connection = useConnection();
@@ -831,9 +837,9 @@ export const AuctionCard = ({
       return (
         <CrossMintButton
           listingId={auctionView.auction.pubkey}
-          collectionDescription={storefront.meta.description}
-          collectionTitle={storefront.meta.title}
-          collectionPhoto={storefront.theme.logo}
+          collectionDescription={artDescription || storefront.meta.description}
+          collectionTitle={artTitle || storefront.meta.title}
+          collectionPhoto={artImage || storefront.theme.logo}
           // todo -- rmv inline styles once this component is testable.
           style={{
             width: '100%',
@@ -1134,7 +1140,7 @@ export const AuctionCard = ({
                 </>
               )}
             {showPlaceBidButton && PlaceBidBtn}
-            {actuallyShowPlaceBidUI && PlaceBidUI} 
+            {actuallyShowPlaceBidUI && PlaceBidUI}
             {maybeCrossMintButton(auctionView, storefront)}
           </>
         )}

--- a/js/packages/web/src/views/auction/index.tsx
+++ b/js/packages/web/src/views/auction/index.tsx
@@ -281,7 +281,13 @@ export const AuctionView = () => {
         <div className="margin-bottom-7">
           {!auction && <Skeleton paragraph={{ rows: 6 }} />}
           {auction && (
-            <AuctionCard auctionView={auction} hideDefaultAction={false} />
+            <AuctionCard
+              auctionView={auction}
+              hideDefaultAction={false}
+              artDescription={description}
+              artTitle={art.title}
+              artImage={data?.image}
+            />
           )}
         </div>
         {!auction?.isInstantSale && <AuctionBids auctionView={auction} />}
@@ -390,7 +396,7 @@ export const AuctionBids = ({
           <ul role="list" className="divide-y divide-color-border">
             {bidLines}
             {/* {bids.map(bid => (
-              
+
               <BidLine bid={bid} key={bid.pubkey} mint={mint} />
             ))} */}
           </ul>


### PR DESCRIPTION
Show auction-specific metadata during checkout, with fallback to default store metadata

![image](https://user-images.githubusercontent.com/93682696/156687066-ed802d90-490e-408a-91e9-a815ee88bb5d.png)
