### PR TITLE
Use regular table to prevent page crash

### DIFF
--- a/js/packages/web/.prettierrc
+++ b/js/packages/web/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": true,
+    "singleQuote": true,
+    "printWidth": 100
+}

--- a/js/packages/web/src/hooks/useNotifications.ts
+++ b/js/packages/web/src/hooks/useNotifications.ts
@@ -7,11 +7,7 @@ import {
   WalletSigner,
   useMeta,
 } from '@oyster/common';
-import {
-  startAuctionManually,
-  decommAuctionManagerAndReturnPrizes,
-  unwindVault,
-} from '../actions';
+import { startAuctionManually, decommAuctionManagerAndReturnPrizes, unwindVault } from '../actions';
 import { useCompactAuctions } from './useAuctions';
 
 export enum StorefrontNotificationType {
@@ -20,7 +16,7 @@ export enum StorefrontNotificationType {
   Unwind,
 }
 
-interface StorefrontNotification {
+export interface StorefrontNotification {
   accountPubkey: StringPublicKey;
   type: StorefrontNotificationType;
   description: string;
@@ -28,9 +24,7 @@ interface StorefrontNotification {
   action: () => Promise<void>;
 }
 
-export const useNotifications = (
-  wallet: WalletSigner,
-): StorefrontNotification[] => {
+export const useNotifications = (wallet: WalletSigner): StorefrontNotification[] => {
   const auctions = useCompactAuctions();
   const connection = useConnection();
   const { vaults } = useMeta();
@@ -38,11 +32,10 @@ export const useNotifications = (
 
   let notifications = [] as StorefrontNotification[];
 
-  auctions.forEach(auctionView => {
+  auctions.forEach((auctionView) => {
     if (
       auctionView.auction.info.state === AuctionState.Created &&
-      auctionView.auctionManager.info.state.status ===
-        AuctionManagerStatus.Validated &&
+      auctionView.auctionManager.info.state.status === AuctionManagerStatus.Validated &&
       auctionView.auctionManager.info.authority === walletPubkey
     ) {
       const upcoming = {
@@ -51,16 +44,14 @@ export const useNotifications = (
         description:
           'You have an auction that has not started yet. If you want start the auction now.',
         callToAction: 'Start Auction',
-        action: async () =>
-          startAuctionManually(connection, wallet, auctionView.auctionManager),
+        action: async () => startAuctionManually(connection, wallet, auctionView.auctionManager),
       };
 
       notifications = [...notifications, upcoming];
     }
 
     if (
-      auctionView.auctionManager.info.state.status ===
-        AuctionManagerStatus.Initialized &&
+      auctionView.auctionManager.info.state.status === AuctionManagerStatus.Initialized &&
       auctionView.auctionManager.info.authority === walletPubkey
     ) {
       const possiblyBroken = {
@@ -69,15 +60,14 @@ export const useNotifications = (
         description:
           'You have an NFT locked in a defective listing. Decommission it now to re-claim the NFT.',
         callToAction: 'Decommission Listing',
-        action: async () =>
-          decommAuctionManagerAndReturnPrizes(connection, wallet, auctionView),
+        action: async () => decommAuctionManagerAndReturnPrizes(connection, wallet, auctionView),
       };
 
       notifications = [...notifications, possiblyBroken];
     }
   });
 
-  Object.values(vaults).forEach(vault => {
+  Object.values(vaults).forEach((vault) => {
     if (
       vault.info.state != VaultState.Deactivated &&
       vault.info.authority === walletPubkey &&

--- a/js/packages/web/src/views/admin/index.tsx
+++ b/js/packages/web/src/views/admin/index.tsx
@@ -30,7 +30,7 @@ import { Link } from 'react-router-dom';
 import { SetupVariables } from '../../components/SetupVariables';
 import { cacheAllAuctions } from '../../actions';
 import { LoadingOutlined } from '@ant-design/icons';
-import { useAuctionManagersToCache, useNotifications } from '../../hooks';
+import { StorefrontNotification, useAuctionManagersToCache, useNotifications } from '../../hooks';
 import Bugsnag from '@bugsnag/browser';
 import { CrossMintStatusButton } from '@crossmint/client-sdk-react-ui';
 import styled from 'styled-components';
@@ -48,11 +48,10 @@ export const AdminView = () => {
   const wallet = useWallet();
   const [loadingAdmin, setLoadingAdmin] = useState(true);
   const { setVisible } = useWalletModal();
-  const connect = useCallback(() => (wallet.wallet ? wallet.connect().catch() : setVisible(true)), [
-    wallet.wallet,
-    wallet.connect,
-    setVisible,
-  ]);
+  const connect = useCallback(
+    () => (wallet.wallet ? wallet.connect().catch() : setVisible(true)),
+    [wallet.wallet, wallet.connect, setVisible]
+  );
   const { storeAddress, setStoreForOwner, isConfigured } = useStore();
 
   useEffect(() => {
@@ -98,7 +97,7 @@ export const AdminView = () => {
 
   if (loadingAdmin) {
     return (
-      <div className='app-section--loading'>
+      <div className="app-section--loading">
         <Spin indicator={<LoadingOutlined />} />
       </div>
     );
@@ -108,7 +107,7 @@ export const AdminView = () => {
     <>
       {!wallet.connected ? (
         <p>
-          <Button type='primary' onClick={connect}>
+          <Button type="primary" onClick={connect}>
             Connect
           </Button>{' '}
           to admin store.
@@ -142,14 +141,14 @@ export const AdminView = () => {
       ) : (
         <>
           <p>Store is not initialized</p>
-          <Link to='/'>Go to initialize</Link>
+          <Link to="/">Go to initialize</Link>
         </>
       )}
     </>
   );
 };
 
-function ArtistModal ({
+function ArtistModal({
   setUpdatedCreators,
   uniqueCreatorsWithUpdates,
   showAddCreatorModal: modalOpen,
@@ -165,7 +164,7 @@ function ArtistModal ({
   return (
     <>
       <Modal
-        title='Add New Artist Address'
+        title="Add New Artist Address"
         visible={modalOpen}
         onOk={() => {
           const addressToAdd = modalAddress;
@@ -183,7 +182,7 @@ function ArtistModal ({
           let address: StringPublicKey;
           try {
             address = addressToAdd;
-            setUpdatedCreators(u => ({
+            setUpdatedCreators((u) => ({
               ...u,
               [modalAddress]: new WhitelistedCreator({
                 address,
@@ -202,7 +201,7 @@ function ArtistModal ({
           setModalOpen(false);
         }}
       >
-        <Input value={modalAddress} onChange={e => setModalAddress(e.target.value)} />
+        <Input value={modalAddress} onChange={(e) => setModalAddress(e.target.value)} />
       </Modal>
       {/* <Button onClick={() => setModalOpen(true)}>Add Creator</Button> */}
     </>
@@ -216,7 +215,7 @@ enum ListingNotificationStatus {
   Error,
 }
 
-function InnerAdminView ({
+function InnerAdminView({
   store,
   whitelistedCreatorsByCreator,
   connection,
@@ -240,11 +239,8 @@ function InnerAdminView ({
   const [showAddCreatorModal, setShowAddCreatorModal] = useState<boolean>(false);
   const [convertingMasterEditions, setConvertMasterEditions] = useState<boolean>();
   const { auctionCaches, storeIndexer, metadata, masterEditions } = useMeta();
-  const {
-    auctionManagersToCache,
-    auctionManagerTotal,
-    auctionCacheTotal,
-  } = useAuctionManagersToCache();
+  const { auctionManagersToCache, auctionManagerTotal, auctionCacheTotal } =
+    useAuctionManagersToCache();
   const notifications = useNotifications(wallet);
 
   const { accountByMint } = useUserAccounts();
@@ -293,11 +289,11 @@ function InnerAdminView ({
         }
       ) => (
         <Switch
-          checkedChildren='Active'
-          unCheckedChildren='Inactive'
+          checkedChildren="Active"
+          unCheckedChildren="Inactive"
           checked={value}
-          onChange={val =>
-            setUpdatedCreators(u => ({
+          onChange={(val) =>
+            setUpdatedCreators((u) => ({
               ...u,
               [record.key]: new WhitelistedCreator({
                 activated: val,
@@ -312,8 +308,8 @@ function InnerAdminView ({
 
   return (
     <>
-      <div className='metaplex-flex metaplex-align-items-center metaplex-justify-content-sb metaplex-margin-bottom-8 metaplex-gap-4 metaplex-flex-wrap'>
-        <h2 className=''>Whitelisted Creators</h2>
+      <div className="metaplex-flex metaplex-align-items-center metaplex-justify-content-sb metaplex-margin-bottom-8 metaplex-gap-4 metaplex-flex-wrap">
+        <h2 className="">Whitelisted Creators</h2>
         <div>
           <Button
             onClick={async () => {
@@ -327,15 +323,15 @@ function InnerAdminView ({
                 type: 'success',
               });
             }}
-            size='large'
-            type='primary'
+            size="large"
+            type="primary"
           >
             Submit changes
           </Button>
         </div>
       </div>
-      <div className='metaplex-flex-column metaplex-gap-4 '>
-        <div className='metaplex-flex'>
+      <div className="metaplex-flex-column metaplex-gap-4 ">
+        <div className="metaplex-flex">
           <ArtistModal
             setUpdatedCreators={setUpdatedCreators}
             uniqueCreatorsWithUpdates={uniqueCreatorsWithUpdates}
@@ -343,12 +339,12 @@ function InnerAdminView ({
             setShowAddCreatorModal={setShowAddCreatorModal}
           />
         </div>
-        <div className='flex items-end justify-between'>
+        <div className="flex items-end justify-between">
           <Switch
-            checkedChildren='Public'
-            unCheckedChildren='Whitelist Only'
+            checkedChildren="Public"
+            unCheckedChildren="Whitelist Only"
             checked={newStore.public}
-            onChange={val => {
+            onChange={(val) => {
               setNewStore(() => {
                 const newS = new Store(store.info);
                 newS.public = val;
@@ -361,7 +357,7 @@ function InnerAdminView ({
 
         <Table
           columns={columns}
-          dataSource={Object.keys(uniqueCreatorsWithUpdates).map(key => ({
+          dataSource={Object.keys(uniqueCreatorsWithUpdates).map((key) => ({
             key,
             address: uniqueCreatorsWithUpdates[key].address,
             activated: uniqueCreatorsWithUpdates[key].activated,
@@ -372,65 +368,13 @@ function InnerAdminView ({
           }))}
         />
 
-        <h2>Listing Notifications</h2>
-        <div className='flex flex-col'>
-          <div className='overflow-x-auto sm:-mx-6 lg:-mx-8'>
-            <div className='inline-block min-w-full py-2 sm:px-6 lg:px-8'>
-              <div className='overflow-hidden shadow-md sm:rounded-lg'>
-                <table className='min-w-full'>
-                  <thead className='bg-gray-700'>
-                    <tr>
-                      <th
-                        scope='col'
-                        className='px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-400 uppercase'
-                      >
-                        Listing
-                      </th>
-                      <th
-                        scope='col'
-                        className='px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-400 uppercase'
-                      >
-                        Notification
-                      </th>
-                      <th scope='col' className='relative px-6 py-3'>
-                        <span className='sr-only'>Action</span>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {notifications.map(n => (
-                      <tr className='border-b'>
-                        <td className='px-6 py-4 text-sm text-white font-mediumwhitespace-nowrap'>
-                          {n.accountPubkey}{' '}
-                        </td>
-                        <td className='px-6 py-4 text-sm text-gray-400 whitespace-nowrap'>
-                          {n.description}
-                        </td>
-
-                        <td className='px-6 py-4 text-sm font-medium text-right whitespace-nowrap'>
-                          <Button
-                            onClick={async () => {
-                              await n.action();
-                            }}
-                            className='text-blue-600 dark:text-blue-500 hover:underline'
-                          >
-                            Action
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-        </div>
+        <ListingNotificationTable notifications={notifications} />
 
         <h2>Credit Card Payments</h2>
-        <div className='metaplex-flex-column metaplex-gap-4'>
+        <div className="metaplex-flex-column metaplex-gap-4">
           <p>
             Increase your sales by accepting credit and debit card payments using&nbsp;
-            <StyledLink href='https://www.crossmint.io/creators' target='_blank' rel='noreferrer'>
+            <StyledLink href="https://www.crossmint.io/creators" target="_blank" rel="noreferrer">
               Crossmint
             </StyledLink>
             . Crossmint is 100% free for sellers.
@@ -442,9 +386,9 @@ function InnerAdminView ({
               <p>
                 NOTE: Your store is not yet ready to use Crossmint. To get started, please visit{' '}
                 <StyledLink
-                  href='https://www.holaplex.com/storefront/edit'
-                  target='_blank'
-                  rel='noreferrer'
+                  href="https://www.holaplex.com/storefront/edit"
+                  target="_blank"
+                  rel="noreferrer"
                 >
                   https://www.holaplex.com/storefront/edit
                 </StyledLink>
@@ -459,10 +403,10 @@ function InnerAdminView ({
           </p>
         </div>
 
-        <div className='metaplex-flex-column metaplex-gap-4'>
+        <div className="metaplex-flex-column metaplex-gap-4">
           <h2>Administrator Actions</h2>
-          <div className='metaplex-flex metaplex-gap-4'>
-            <div className='metaplex-width-50'>
+          <div className="metaplex-flex metaplex-gap-4">
+            <div className="metaplex-width-50">
               <h3>Convert Master Editions</h3>
               <p>
                 You have {filteredMetadata?.available.length} MasterEditionV1s that can be converted
@@ -470,7 +414,7 @@ function InnerAdminView ({
                 that cannot be converted yet.
               </p>
               <Button
-                size='large'
+                size="large"
                 loading={convertingMasterEditions}
                 onClick={async () => {
                   setConvertMasterEditions(true);
@@ -488,7 +432,7 @@ function InnerAdminView ({
                 Convert Eligible Master Editions
               </Button>
             </div>
-            <div className='metaplex-width-50'>
+            <div className="metaplex-width-50">
               <h3>Cache Auctions</h3>
               <p>
                 Activate your storefront listing caches by pressing &ldquo;build cache&rdquo;. This
@@ -496,8 +440,8 @@ function InnerAdminView ({
                 listing using the cache on November 17th. To preview the speed improvement visit the
                 Holaplex{' '}
                 <a
-                  rel='noopener noreferrer'
-                  target='_blank'
+                  rel="noopener noreferrer"
+                  target="_blank"
                   href={`https://${storefront.subdomain}.holaxplex.dev`}
                 >
                   {' '}
@@ -505,16 +449,16 @@ function InnerAdminView ({
                 </a>{' '}
                 for your storefront.
               </p>
-              <Space direction='vertical' size='middle' align='center'>
+              <Space direction="vertical" size="middle" align="center">
                 <Progress
-                  type='circle'
-                  status='normal'
+                  type="circle"
+                  status="normal"
                   percent={(auctionCacheTotal / auctionManagerTotal) * 100}
                   format={() => `${auctionManagersToCache.length} left`}
                 />
                 {auctionManagersToCache.length > 0 && (
                   <Button
-                    size='large'
+                    size="large"
                     loading={cachingAuctions}
                     onClick={async () => {
                       setCachingAuctions(true);
@@ -541,7 +485,7 @@ function InnerAdminView ({
         </div>
         <h2>Miscellaneous</h2>
         <div>
-          <Button type='primary' onClick={() => localStorage.clear()}>
+          <Button type="primary" onClick={() => localStorage.clear()}>
             Clear Local Cache
           </Button>
         </div>
@@ -549,3 +493,81 @@ function InnerAdminView ({
     </>
   );
 }
+
+const ListingNotificationTable = ({
+  notifications,
+}: {
+  notifications: StorefrontNotification[];
+}) => {
+  return (
+    <>
+      <h2>Listing Notifications</h2>
+      <div className="flex flex-col">
+        <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div className="inline-block min-w-full py-2 sm:px-6 lg:px-8">
+            <div className="overflow-hidden shadow-md sm:rounded-lg">
+              <table className="min-w-full">
+                <thead className="bg-gray-700">
+                  <tr>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-400 uppercase"
+                    >
+                      Listing
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-400 uppercase"
+                    >
+                      Notification
+                    </th>
+                    <th scope="col" className="relative px-6 py-3">
+                      <span className="sr-only">Action</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {notifications.map((n) => (
+                    <tr className="border-b" key={n.accountPubkey + n.description}>
+                      <td className="px-6 py-4 text-sm text-white font-mediumwhitespace-nowrap">
+                        {n.accountPubkey}
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-400 whitespace-nowrap">
+                        {n.description}
+                      </td>
+
+                      <td className="px-6 py-4 text-sm font-medium text-right whitespace-nowrap">
+                        <NotificationButton action={n.action} callToAction={n.callToAction} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+const NotificationButton = ({ action, callToAction }: { action: any; callToAction?: string }) => {
+  const [status, setStatus] = useState<ListingNotificationStatus>(ListingNotificationStatus.Ready);
+
+  const onSubmit = async () => {
+    try {
+      setStatus(ListingNotificationStatus.Submitting);
+      await action();
+      setStatus(ListingNotificationStatus.Complete);
+    } catch (e: any) {
+      Bugsnag.notify(e);
+      setStatus(ListingNotificationStatus.Error);
+    }
+  };
+
+  const isComplete = status === ListingNotificationStatus.Complete;
+
+  const label = isComplete ? 'Done' : callToAction || 'Action';
+
+  return <Button onClick={onSubmit}>{label}</Button>;
+};

--- a/js/packages/web/src/views/admin/index.tsx
+++ b/js/packages/web/src/views/admin/index.tsx
@@ -56,8 +56,12 @@ const StyledLink = styled.a`
 `;
 
 export const AdminView = () => {
-  const { store, whitelistedCreatorsByCreator, isLoading, patchState } =
-    useMeta();
+  const {
+    store,
+    whitelistedCreatorsByCreator,
+    isLoading,
+    patchState,
+  } = useMeta();
   const connection = useConnection();
   const wallet = useWallet();
   const [loadingAdmin, setLoadingAdmin] = useState(true);
@@ -111,7 +115,7 @@ export const AdminView = () => {
 
   if (loadingAdmin) {
     return (
-      <div className="app-section--loading">
+      <div className='app-section--loading'>
         <Spin indicator={<LoadingOutlined />} />
       </div>
     );
@@ -121,7 +125,7 @@ export const AdminView = () => {
     <>
       {!wallet.connected ? (
         <p>
-          <Button type="primary" onClick={connect}>
+          <Button type='primary' onClick={connect}>
             Connect
           </Button>{' '}
           to admin store.
@@ -155,14 +159,14 @@ export const AdminView = () => {
       ) : (
         <>
           <p>Store is not initialized</p>
-          <Link to="/">Go to initialize</Link>
+          <Link to='/'>Go to initialize</Link>
         </>
       )}
     </>
   );
 };
 
-function ArtistModal({
+function ArtistModal ({
   setUpdatedCreators,
   uniqueCreatorsWithUpdates,
   showAddCreatorModal: modalOpen,
@@ -180,7 +184,7 @@ function ArtistModal({
   return (
     <>
       <Modal
-        title="Add New Artist Address"
+        title='Add New Artist Address'
         visible={modalOpen}
         onOk={() => {
           const addressToAdd = modalAddress;
@@ -234,7 +238,7 @@ enum ListingNotificationStatus {
   Error,
 }
 
-function InnerAdminView({
+function InnerAdminView ({
   store,
   whitelistedCreatorsByCreator,
   connection,
@@ -262,13 +266,18 @@ function InnerAdminView({
     unavailable: ParsedAccount<MasterEditionV1>[];
   }>();
   const [cachingAuctions, setCachingAuctions] = useState<boolean>();
-  const [showAddCreatorModal, setShowAddCreatorModal] =
-    useState<boolean>(false);
-  const [convertingMasterEditions, setConvertMasterEditions] =
-    useState<boolean>();
+  const [showAddCreatorModal, setShowAddCreatorModal] = useState<boolean>(
+    false,
+  );
+  const [convertingMasterEditions, setConvertMasterEditions] = useState<
+    boolean
+  >();
   const { auctionCaches, storeIndexer, metadata, masterEditions } = useMeta();
-  const { auctionManagersToCache, auctionManagerTotal, auctionCacheTotal } =
-    useAuctionManagersToCache();
+  const {
+    auctionManagersToCache,
+    auctionManagerTotal,
+    auctionCacheTotal,
+  } = useAuctionManagersToCache();
   const notifications = useNotifications(wallet);
 
   const { accountByMint } = useUserAccounts();
@@ -322,8 +331,8 @@ function InnerAdminView({
         },
       ) => (
         <Switch
-          checkedChildren="Active"
-          unCheckedChildren="Inactive"
+          checkedChildren='Active'
+          unCheckedChildren='Inactive'
           checked={value}
           onChange={val =>
             setUpdatedCreators(u => ({
@@ -341,8 +350,8 @@ function InnerAdminView({
 
   return (
     <>
-      <div className="metaplex-flex metaplex-align-items-center metaplex-justify-content-sb metaplex-margin-bottom-8 metaplex-gap-4 metaplex-flex-wrap">
-        <h2 className="">Whitelisted Creators</h2>
+      <div className='metaplex-flex metaplex-align-items-center metaplex-justify-content-sb metaplex-margin-bottom-8 metaplex-gap-4 metaplex-flex-wrap'>
+        <h2 className=''>Whitelisted Creators</h2>
         <div>
           <Button
             onClick={async () => {
@@ -361,15 +370,15 @@ function InnerAdminView({
                 type: 'success',
               });
             }}
-            size="large"
-            type="primary"
+            size='large'
+            type='primary'
           >
             Submit changes
           </Button>
         </div>
       </div>
-      <div className="metaplex-flex-column metaplex-gap-4 ">
-        <div className="metaplex-flex">
+      <div className='metaplex-flex-column metaplex-gap-4 '>
+        <div className='metaplex-flex'>
           <ArtistModal
             setUpdatedCreators={setUpdatedCreators}
             uniqueCreatorsWithUpdates={uniqueCreatorsWithUpdates}
@@ -377,10 +386,10 @@ function InnerAdminView({
             setShowAddCreatorModal={setShowAddCreatorModal}
           />
         </div>
-        <div className="flex items-end justify-between">
+        <div className='flex items-end justify-between'>
           <Switch
-            checkedChildren="Public"
-            unCheckedChildren="Whitelist Only"
+            checkedChildren='Public'
+            unCheckedChildren='Whitelist Only'
             checked={newStore.public}
             onChange={val => {
               setNewStore(() => {
@@ -409,64 +418,68 @@ function InnerAdminView({
         />
 
         <h2>Listing Notifications</h2>
-        <Table
-          columns={[
-            {
-              key: 'accountPubkey',
-              title: 'Listing',
-              dataIndex: 'accountPubkey',
-            },
-            {
-              key: 'description',
-              title: 'Notification',
-              dataIndex: 'description',
-            },
-            {
-              key: 'action',
-              title: 'Action',
-              render: ({ action, callToAction }) => {
-                const [status, setStatus] = useState<ListingNotificationStatus>(
-                  ListingNotificationStatus.Ready,
-                );
+        <div className='flex flex-col'>
+          <div className='overflow-x-auto sm:-mx-6 lg:-mx-8'>
+            <div className='inline-block min-w-full py-2 sm:px-6 lg:px-8'>
+              <div className='overflow-hidden shadow-md sm:rounded-lg'>
+                <table className='min-w-full'>
+                  <thead className='bg-gray-700'>
+                    <tr>
+                      <th
+                        scope='col'
+                        className='px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-400 uppercase'
+                      >
+                        Listing
+                      </th>
+                      <th
+                        scope='col'
+                        className='px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-400 uppercase'
+                      >
+                        Notification
+                      </th>
+                      <th scope='col' className='relative px-6 py-3'>
+                        <span className='sr-only'>Action</span>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {notifications.map(n => (
+                      <tr className='border-b'>
+                        <td className='px-6 py-4 text-sm text-white font-mediumwhitespace-nowrap'>
+                          {n.accountPubkey}{' '}
+                        </td>
+                        <td className='px-6 py-4 text-sm text-gray-400 whitespace-nowrap'>
+                          {n.description}
+                        </td>
 
-                const onSubmit = async () => {
-                  try {
-                    setStatus(ListingNotificationStatus.Submitting);
-                    await action();
-                    setStatus(ListingNotificationStatus.Complete);
-                  } catch (e: any) {
-                    Bugsnag.notify(e);
-                    setStatus(ListingNotificationStatus.Error);
-                  }
-                };
-                const isComplete =
-                  status === ListingNotificationStatus.Complete;
-
-                const label = isComplete ? 'Done' : callToAction;
-                return (
-                  <Button
-                    loading={status === ListingNotificationStatus.Submitting}
-                    disabled={isComplete}
-                    onClick={onSubmit}
-                  >
-                    {label}
-                  </Button>
-                );
-              },
-            },
-          ]}
-          dataSource={notifications}
-        />
+                        <td className='px-6 py-4 text-sm font-medium text-right whitespace-nowrap'>
+                          <Button
+                            onClick={async () => {
+                              await n.action();
+                            }}
+                            className='text-blue-600 dark:text-blue-500 hover:underline'
+                          >
+                            Action
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
 
         <h2>Credit Card Payments</h2>
-        <div className="metaplex-flex-column metaplex-gap-4">
+        <div className='metaplex-flex-column metaplex-gap-4'>
           <p>
             Increase your sales by accepting credit and debit card payments
             using&nbsp;
             <StyledLink
-              href="https://www.crossmint.io/creators"
-              target="_blank"
-              rel="noreferrer"
+              href='https://www.crossmint.io/creators'
+              target='_blank'
+              rel='noreferrer'
             >
               Crossmint
             </StyledLink>
@@ -480,9 +493,9 @@ function InnerAdminView({
                 NOTE: Your store is not yet ready to use Crossmint. To get
                 started, please visit{' '}
                 <StyledLink
-                  href="https://www.holaplex.com/storefront/edit"
-                  target="_blank"
-                  rel="noreferrer"
+                  href='https://www.holaplex.com/storefront/edit'
+                  target='_blank'
+                  rel='noreferrer'
                 >
                   https://www.holaplex.com/storefront/edit
                 </StyledLink>
@@ -498,10 +511,10 @@ function InnerAdminView({
           </p>
         </div>
 
-        <div className="metaplex-flex-column metaplex-gap-4">
+        <div className='metaplex-flex-column metaplex-gap-4'>
           <h2>Administrator Actions</h2>
-          <div className="metaplex-flex metaplex-gap-4">
-            <div className="metaplex-width-50">
+          <div className='metaplex-flex metaplex-gap-4'>
+            <div className='metaplex-width-50'>
               <h3>Convert Master Editions</h3>
               <p>
                 You have {filteredMetadata?.available.length} MasterEditionV1s
@@ -510,7 +523,7 @@ function InnerAdminView({
                 auctions that cannot be converted yet.
               </p>
               <Button
-                size="large"
+                size='large'
                 loading={convertingMasterEditions}
                 onClick={async () => {
                   setConvertMasterEditions(true);
@@ -528,7 +541,7 @@ function InnerAdminView({
                 Convert Eligible Master Editions
               </Button>
             </div>
-            <div className="metaplex-width-50">
+            <div className='metaplex-width-50'>
               <h3>Cache Auctions</h3>
               <p>
                 Activate your storefront listing caches by pressing &ldquo;build
@@ -537,8 +550,8 @@ function InnerAdminView({
                 the cache on November 17th. To preview the speed improvement
                 visit the Holaplex{' '}
                 <a
-                  rel="noopener noreferrer"
-                  target="_blank"
+                  rel='noopener noreferrer'
+                  target='_blank'
                   href={`https://${storefront.subdomain}.holaxplex.dev`}
                 >
                   {' '}
@@ -546,16 +559,16 @@ function InnerAdminView({
                 </a>{' '}
                 for your storefront.
               </p>
-              <Space direction="vertical" size="middle" align="center">
+              <Space direction='vertical' size='middle' align='center'>
                 <Progress
-                  type="circle"
-                  status="normal"
+                  type='circle'
+                  status='normal'
                   percent={(auctionCacheTotal / auctionManagerTotal) * 100}
                   format={() => `${auctionManagersToCache.length} left`}
                 />
                 {auctionManagersToCache.length > 0 && (
                   <Button
-                    size="large"
+                    size='large'
                     loading={cachingAuctions}
                     onClick={async () => {
                       setCachingAuctions(true);
@@ -582,7 +595,7 @@ function InnerAdminView({
         </div>
         <h2>Miscellaneous</h2>
         <div>
-          <Button type="primary" onClick={() => localStorage.clear()}>
+          <Button type='primary' onClick={() => localStorage.clear()}>
             Clear Local Cache
           </Button>
         </div>

--- a/js/packages/web/src/views/admin/index.tsx
+++ b/js/packages/web/src/views/admin/index.tsx
@@ -1,15 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  Table,
-  Switch,
-  Spin,
-  Modal,
-  Button,
-  Input,
-  Divider,
-  Progress,
-  Space,
-} from 'antd';
+import { Table, Switch, Spin, Modal, Button, Input, Divider, Progress, Space } from 'antd';
 import { useMeta } from '../../contexts';
 import {
   Store,
@@ -35,10 +25,7 @@ import {
 import { useWallet } from '@solana/wallet-adapter-react';
 import { Connection } from '@solana/web3.js';
 import { saveAdmin } from '../../actions/saveAdmin';
-import {
-  convertMasterEditions,
-  filterMetadata,
-} from '../../actions/convertMasterEditions';
+import { convertMasterEditions, filterMetadata } from '../../actions/convertMasterEditions';
 import { Link } from 'react-router-dom';
 import { SetupVariables } from '../../components/SetupVariables';
 import { cacheAllAuctions } from '../../actions';
@@ -56,20 +43,16 @@ const StyledLink = styled.a`
 `;
 
 export const AdminView = () => {
-  const {
-    store,
-    whitelistedCreatorsByCreator,
-    isLoading,
-    patchState,
-  } = useMeta();
+  const { store, whitelistedCreatorsByCreator, isLoading, patchState } = useMeta();
   const connection = useConnection();
   const wallet = useWallet();
   const [loadingAdmin, setLoadingAdmin] = useState(true);
   const { setVisible } = useWalletModal();
-  const connect = useCallback(
-    () => (wallet.wallet ? wallet.connect().catch() : setVisible(true)),
-    [wallet.wallet, wallet.connect, setVisible],
-  );
+  const connect = useCallback(() => (wallet.wallet ? wallet.connect().catch() : setVisible(true)), [
+    wallet.wallet,
+    wallet.connect,
+    setVisible,
+  ]);
   const { storeAddress, setStoreForOwner, isConfigured } = useStore();
 
   useEffect(() => {
@@ -101,11 +84,11 @@ export const AdminView = () => {
       ]);
       const auctionsState = await loadAuctionsForAuctionManagers(
         connection,
-        Object.values(auctionManagerState.auctionManagersByAuction),
+        Object.values(auctionManagerState.auctionManagersByAuction)
       );
       const vaultState = await loadVaultsAndContentForAuthority(
         connection,
-        wallet.publicKey?.toBase58() as string,
+        wallet.publicKey?.toBase58() as string
       );
 
       patchState(creatorsState, auctionManagerState, auctionsState, vaultState);
@@ -146,8 +129,8 @@ export const AdminView = () => {
               <Divider />
               <Divider />
               <p>
-                To finish initialization please copy config below into{' '}
-                <b>packages/web/.env</b> and restart yarn or redeploy
+                To finish initialization please copy config below into <b>packages/web/.env</b> and
+                restart yarn or redeploy
               </p>
               <SetupVariables
                 storeAddress={storeAddress}
@@ -172,9 +155,7 @@ function ArtistModal ({
   showAddCreatorModal: modalOpen,
   setShowAddCreatorModal: setModalOpen,
 }: {
-  setUpdatedCreators: React.Dispatch<
-    React.SetStateAction<Record<string, WhitelistedCreator>>
-  >;
+  setUpdatedCreators: React.Dispatch<React.SetStateAction<Record<string, WhitelistedCreator>>>;
   uniqueCreatorsWithUpdates: Record<string, WhitelistedCreator>;
   showAddCreatorModal: boolean;
   setShowAddCreatorModal: (openStatus: boolean) => void;
@@ -221,10 +202,7 @@ function ArtistModal ({
           setModalOpen(false);
         }}
       >
-        <Input
-          value={modalAddress}
-          onChange={e => setModalAddress(e.target.value)}
-        />
+        <Input value={modalAddress} onChange={e => setModalAddress(e.target.value)} />
       </Modal>
       {/* <Button onClick={() => setModalOpen(true)}>Add Creator</Button> */}
     </>
@@ -246,32 +224,21 @@ function InnerAdminView ({
   connected,
 }: {
   store: ParsedAccount<Store>;
-  whitelistedCreatorsByCreator: Record<
-    string,
-    ParsedAccount<WhitelistedCreator>
-  >;
+  whitelistedCreatorsByCreator: Record<string, ParsedAccount<WhitelistedCreator>>;
   connection: Connection;
   wallet: WalletSigner;
   connected: boolean;
 }) {
-  const [newStore, setNewStore] = useState(
-    store && store.info && new Store(store.info),
-  );
+  const [newStore, setNewStore] = useState(store && store.info && new Store(store.info));
   const { storefront } = useStore();
-  const [updatedCreators, setUpdatedCreators] = useState<
-    Record<string, WhitelistedCreator>
-  >({});
+  const [updatedCreators, setUpdatedCreators] = useState<Record<string, WhitelistedCreator>>({});
   const [filteredMetadata, setFilteredMetadata] = useState<{
     available: ParsedAccount<MasterEditionV1>[];
     unavailable: ParsedAccount<MasterEditionV1>[];
   }>();
   const [cachingAuctions, setCachingAuctions] = useState<boolean>();
-  const [showAddCreatorModal, setShowAddCreatorModal] = useState<boolean>(
-    false,
-  );
-  const [convertingMasterEditions, setConvertMasterEditions] = useState<
-    boolean
-  >();
+  const [showAddCreatorModal, setShowAddCreatorModal] = useState<boolean>(false);
+  const [convertingMasterEditions, setConvertMasterEditions] = useState<boolean>();
   const { auctionCaches, storeIndexer, metadata, masterEditions } = useMeta();
   const {
     auctionManagersToCache,
@@ -284,12 +251,7 @@ function InnerAdminView ({
   useMemo(() => {
     const fn = async () => {
       setFilteredMetadata(
-        await filterMetadata(
-          connection,
-          metadata,
-          masterEditions,
-          accountByMint,
-        ),
+        await filterMetadata(connection, metadata, masterEditions, accountByMint)
       );
     };
     fn();
@@ -300,7 +262,7 @@ function InnerAdminView ({
       acc[e.info.address] = e.info;
       return acc;
     },
-    {},
+    {}
   );
 
   const uniqueCreatorsWithUpdates = { ...uniqueCreators, ...updatedCreators };
@@ -328,7 +290,7 @@ function InnerAdminView ({
           activated: boolean;
           name: string;
           key: string;
-        },
+        }
       ) => (
         <Switch
           checkedChildren='Active'
@@ -359,12 +321,7 @@ function InnerAdminView ({
                 message: 'Saving...',
                 type: 'info',
               });
-              await saveAdmin(
-                connection,
-                wallet,
-                newStore.public,
-                Object.values(updatedCreators),
-              );
+              await saveAdmin(connection, wallet, newStore.public, Object.values(updatedCreators));
               notify({
                 message: 'Saved',
                 type: 'success',
@@ -399,9 +356,7 @@ function InnerAdminView ({
               });
             }}
           />
-          <Button onClick={() => setShowAddCreatorModal(true)}>
-            Add Creator
-          </Button>
+          <Button onClick={() => setShowAddCreatorModal(true)}>Add Creator</Button>
         </div>
 
         <Table
@@ -474,13 +429,8 @@ function InnerAdminView ({
         <h2>Credit Card Payments</h2>
         <div className='metaplex-flex-column metaplex-gap-4'>
           <p>
-            Increase your sales by accepting credit and debit card payments
-            using&nbsp;
-            <StyledLink
-              href='https://www.crossmint.io/creators'
-              target='_blank'
-              rel='noreferrer'
-            >
+            Increase your sales by accepting credit and debit card payments using&nbsp;
+            <StyledLink href='https://www.crossmint.io/creators' target='_blank' rel='noreferrer'>
               Crossmint
             </StyledLink>
             . Crossmint is 100% free for sellers.
@@ -490,8 +440,7 @@ function InnerAdminView ({
               <CrossMintStatusButton style={{ fontWeight: 'normal' }} />
             ) : (
               <p>
-                NOTE: Your store is not yet ready to use Crossmint. To get
-                started, please visit{' '}
+                NOTE: Your store is not yet ready to use Crossmint. To get started, please visit{' '}
                 <StyledLink
                   href='https://www.holaplex.com/storefront/edit'
                   target='_blank'
@@ -499,15 +448,14 @@ function InnerAdminView ({
                 >
                   https://www.holaplex.com/storefront/edit
                 </StyledLink>
-                , connect your wallet, and click on the Update button. Once your
-                store is successfully updated, return here to finish setting up
-                Crossmint.
+                , connect your wallet, and click on the Update button. Once your store is
+                successfully updated, return here to finish setting up Crossmint.
               </p>
             )}
           </div>
           <p>
-            Please note that credit card payments are currently only supported
-            for instant sale auctions. More sale types are coming soon.
+            Please note that credit card payments are currently only supported for instant sale
+            auctions. More sale types are coming soon.
           </p>
         </div>
 
@@ -517,10 +465,9 @@ function InnerAdminView ({
             <div className='metaplex-width-50'>
               <h3>Convert Master Editions</h3>
               <p>
-                You have {filteredMetadata?.available.length} MasterEditionV1s
-                that can be converted right now and{' '}
-                {filteredMetadata?.unavailable.length} still in unfinished
-                auctions that cannot be converted yet.
+                You have {filteredMetadata?.available.length} MasterEditionV1s that can be converted
+                right now and {filteredMetadata?.unavailable.length} still in unfinished auctions
+                that cannot be converted yet.
               </p>
               <Button
                 size='large'
@@ -532,7 +479,7 @@ function InnerAdminView ({
                     connection,
                     wallet,
                     filteredMetadata?.available || [],
-                    accountByMint,
+                    accountByMint
                   );
 
                   setConvertMasterEditions(false);
@@ -544,11 +491,10 @@ function InnerAdminView ({
             <div className='metaplex-width-50'>
               <h3>Cache Auctions</h3>
               <p>
-                Activate your storefront listing caches by pressing &ldquo;build
-                cache&rdquo;. This will reduce page load times for your
-                listings. Your storefront will start looking up listing using
-                the cache on November 17th. To preview the speed improvement
-                visit the Holaplex{' '}
+                Activate your storefront listing caches by pressing &ldquo;build cache&rdquo;. This
+                will reduce page load times for your listings. Your storefront will start looking up
+                listing using the cache on November 17th. To preview the speed improvement visit the
+                Holaplex{' '}
                 <a
                   rel='noopener noreferrer'
                   target='_blank'
@@ -579,7 +525,7 @@ function InnerAdminView ({
                           connection,
                           auctionManagersToCache,
                           auctionCaches,
-                          storeIndexer,
+                          storeIndexer
                         );
                       } finally {
                         setCachingAuctions(false);


### PR DESCRIPTION
Debugging with @kristianeboe and we identified the antd table as the cause for admin page crashing. 

Fix: use plain html table with some style classes. 

@echohtp was able to unwind a locked vault as a working poc.