### PR TITLE
Fix Settle Funds Action

### DIFF
--- a/js/packages/web/src/views/auction/billing.tsx
+++ b/js/packages/web/src/views/auction/billing.tsx
@@ -26,8 +26,9 @@ import {
   METAPLEX_ID,
   processMetaplexAccounts,
   subscribeProgramChanges,
+  useWallet,
 } from '@oyster/common';
-import { useWallet, WalletContextState } from '@solana/wallet-adapter-react';
+import { WalletContextState } from '@solana/wallet-adapter-react';
 import { useMeta } from '../../contexts';
 import { Connection } from '@solana/web3.js';
 import { settle } from '../../actions/settle';


### PR DESCRIPTION
Settle funds doesnt work with solana/wallet-adapter's `useWallet()` hook.

fix: use oyster/wallet-adapter `useWallet()` hook.